### PR TITLE
Compile Javascript without HTML Parser

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -228,3 +228,10 @@ func replaceJsFuncs(fn string) string {
 	pat, _ := regexp.Compile(`\n|\t`)
 	return pat.ReplaceAllString(fn, "")
 }
+
+// replace and clear up js functions string
+func replaceJsFuncsX(fn string) string {
+	pat, _ := regexp.Compile(`\n|\t`)
+	fn = pat.ReplaceAllString(fn, "")
+	return "__x__" + fn + "__x__"
+}

--- a/charts/base.go
+++ b/charts/base.go
@@ -1,8 +1,9 @@
 package charts
 
 import (
-	"github.com/go-echarts/go-echarts/datatypes"
 	"regexp"
+
+	"github.com/go-echarts/go-echarts/datatypes"
 )
 
 type GlobalOptser interface {
@@ -225,6 +226,5 @@ func reverseSlice(s []string) []string {
 // replace and clear up js functions string
 func replaceJsFuncs(fn string) string {
 	pat, _ := regexp.Compile(`\n|\t`)
-	fn = pat.ReplaceAllString(fn, "")
-	return "__x__" + fn + "__x__"
+	return pat.ReplaceAllString(fn, "")
 }

--- a/charts/components.go
+++ b/charts/components.go
@@ -370,5 +370,5 @@ func (YAxisOpts) MarkGlobal() {}
 
 // FuncOpts is the option set for handling function type.
 func FuncOpts(fn string) string {
-	return replaceJsFuncs(fn)
+	return replaceJsFuncsX(fn)
 }

--- a/charts/engine.go
+++ b/charts/engine.go
@@ -2,6 +2,7 @@ package charts
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 	"io"
 	"math/rand"
@@ -30,7 +31,11 @@ func renderChart(chart interface{}, w io.Writer, name string) error {
 	case "page":
 		contents = append(contents, tpls.PageTpl)
 	}
-	tpl := template.Must(template.New("").Parse(contents[0]))
+	tpl := template.Must(template.New("").Parse(contents[0])).Funcs(template.FuncMap{
+		"safeJS": func(s interface{}) template.JS {
+			return template.JS(fmt.Sprint(s))
+		},
+	})
 	mustTpl(tpl, contents[1:]...)
 	return tpl.ExecuteTemplate(w, name, chart)
 }

--- a/templates/base.go
+++ b/templates/base.go
@@ -60,7 +60,7 @@ var BaseTpl = `
     myChart___x__{{ .ChartID }}__x__.setOption(option___x__{{ .ChartID }}__x__);
 
     {{- range .JSFunctions.Fns }}
-		{{ . }}
+		{{ . | safeJS }}
 	{{- end }}
 </script>
 {{ end }}


### PR DESCRIPTION
I recognized that javascript code which includes gt lt or & or anything else special will not be rendered right.
It will be shown up as /003e... With this small fix all js methods will be rendered right