### PR TITLE
Render Javascript methods as js and not as html

### DIFF
--- a/render/engine.go
+++ b/render/engine.go
@@ -43,7 +43,7 @@ func (r *pageRender) Render(w io.Writer) error {
 		return err
 	}
 
-	pat, _ := regexp.Compile(`(__x__")|("__x__)`)
+	pat, _ := regexp.Compile(`(__x__")|("__x__)|(__x__)`)
 	content := pat.ReplaceAll(buf.Bytes(), []byte(""))
 
 	_, err := w.Write(content)

--- a/render/engine.go
+++ b/render/engine.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 	"io"
 	"regexp"
@@ -82,7 +83,11 @@ func (r *chartRender) Render(w io.Writer) error {
 
 // MustTemplate
 func MustTemplate(name string, contents []string) *template.Template {
-	tpl := template.Must(template.New(name).Parse(contents[0]))
+	tpl := template.Must(template.New(name).Parse(contents[0])).Funcs(template.FuncMap{
+		"safeJS": func(s interface{}) template.JS {
+			return template.JS(fmt.Sprint(s))
+		},
+	})
 	for _, cont := range contents[1:] {
 		tpl = template.Must(tpl.Parse(cont))
 	}

--- a/templates/base.go
+++ b/templates/base.go
@@ -62,7 +62,7 @@ var BaseTpl = `
      myChart___x__{{ .ChartID }}__x__.setOption(option___x__{{ .ChartID }}__x__);
 
      {{- range .JSFunctions.Fns }}
-     {{ . }}
+     {{ . | safeJS }}
      {{- end }}
  </script>
 {{ end }}


### PR DESCRIPTION
Here is a short fix for js functions to work properly without annoying escapes like "/003e" for ">" etc...
It is currently untested because I use currently only the V1 version.
I hope it helps.
Sincerely Stefan