### PR TITLE
Remove unused property.

### DIFF
--- a/charts/chart3d.go
+++ b/charts/chart3d.go
@@ -13,7 +13,6 @@ type Chart3D struct {
 	XAxis3D opts.XAxis3D
 	YAxis3D opts.YAxis3D
 	ZAxis3D opts.ZAxis3D
-	Grid3D  opts.Grid3D
 
 	xData interface{}
 	yData interface{}


### PR DESCRIPTION
There is an unnecessary property in `Chart3D` which will cover the configurations in `setBaseGlobalOptions`. and there is no way to set the `Chart3D.Grid3D`.
```go
func (c *Chart3D) SetGlobalOptions(opts ...GlobalOpts) *Chart3D {
	c.BaseConfiguration.setBaseGlobalOptions(opts...)
	return c
}
```
**Configuration**：
```go
charts.WithGrid3DOpts(opts.Grid3D{
	BoxWidth:    160,
	BoxDepth:    80,
	ViewControl: opts.ViewControl{AutoRotate: true, AutoRotateSpeed: 200},
}),
```

**Before**
```go
zAxis3D: {},
grid3D: {"viewControl":{}},
series: [
```
**After**
```go
zAxis3D: {},
grid3D: {"boxWidth":160,"boxDepth":80,"viewControl":{"autoRotate":true,"autoRotateSpeed":200}},
series: [
```