### PR TITLE
Fix the wrong type name of Line3D.

### DIFF
--- a/types/charts.go
+++ b/types/charts.go
@@ -14,7 +14,7 @@ const (
 	ChartHeatMap       = "heatmap"
 	ChartKline         = "candlestick"
 	ChartLine          = "line"
-	ChartLine3D        = "line3d"
+	ChartLine3D        = "line3D"
 	ChartLiquid        = "liquidFill"
 	ChartMap           = "map"
 	ChartParallel      = "parallel"


### PR DESCRIPTION
Avoid cause error `Component series.line3d not exists. Load it first.`