### PR TITLE
Fix generateUniqueID() returns same strings on windows

### DIFF
--- a/opts/global.go
+++ b/opts/global.go
@@ -77,10 +77,6 @@ func setField(field reflect.Value, defaultVal string) {
 }
 
 const (
-	//	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	//	letterIdxBits = 6                    // 6 bits to represent a letter index
-	//	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	//	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 	chartIDSize = 12
 )
 

--- a/opts/global.go
+++ b/opts/global.go
@@ -12,6 +12,10 @@ import (
 	"github.com/go-echarts/go-echarts/v2/types"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 // Initialization contains options for the canvas.
 type Initialization struct {
 	// HTML title
@@ -73,29 +77,28 @@ func setField(field reflect.Value, defaultVal string) {
 }
 
 const (
-	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
-	chartIDSize   = 12
+	//	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	//	letterIdxBits = 6                    // 6 bits to represent a letter index
+	//	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	//	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	chartIDSize = 12
 )
 
 // generate the unique ID for each chart.
 func generateUniqueID() string {
-	seed := rand.NewSource(time.Now().UnixNano())
-	b := make([]byte, chartIDSize)
-	for i, cache, remain := chartIDSize-1, seed.Int63(), letterIdxMax; i >= 0; {
-		if remain == 0 {
-			cache, remain = seed.Int63(), letterIdxMax
-		}
-		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-			b[i] = letterBytes[idx]
-			i--
-		}
-		cache >>= letterIdxBits
-		remain--
+	var b [chartIDSize]byte
+	for i := range b {
+		b[i] = randByte()
 	}
-	return string(b)
+	return string(b[:])
+}
+
+func randByte() byte {
+	c := 65 // A
+	if rand.Intn(10) > 5 {
+		c = 97 // a
+	}
+	return byte(c + rand.Intn(26))
 }
 
 // Title is the option set for a title component.

--- a/opts/global_test.go
+++ b/opts/global_test.go
@@ -22,3 +22,12 @@ func TestAssets(t *testing.T) {
 	assert.Equal(t, []string{host + "echarts.min.js", host + "jquery.min.js"}, assetsEntity.JSAssets.Values)
 	assert.Equal(t, []string{"http://myhost/my.assets.js"}, assetsEntity.CustomizedJSAssets.Values)
 }
+
+func TestGenerateUniqueID(t *testing.T) {
+	var old string
+	for i := 0; i < 10; i++ {
+		new := generateUniqueID()
+		assert.NotSame(t, old, new)
+		old = new
+	}
+}


### PR DESCRIPTION
When we use generateUniqueID() to generate ChartIDs on windows usually these are not unique, since time.Now().UnixNano() returns same values every few milliseconds on windows.

![image](https://user-images.githubusercontent.com/3397805/99477598-63ff5880-2985-11eb-8da1-dc766b787e01.png)

test case:
```go
func TestGenerateUniqueID(t *testing.T) {
	var old string
	for i := 0; i < 10; i++ {
		new := generateUniqueID()
		assert.NotSame(t, old, new)
		old = new
	}
}
```

