### PR TITLE
Feat: basic sunburst chart

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -52,12 +52,27 @@ type SingleSeries struct {
 	SizeRange     []float32 `json:"sizeRange,omitempty"`
 	RotationRange []float32 `json:"rotationRange,omitempty"`
 
+	// Sunburst
+	NodeClick               string `json:"nodeClick,omitempty"`
+	Sort                    string `json:"sort,omitempty"`
+	RenderLabelForZeroData  bool   `json:"renderLabelForZeroData"`
+	SelectedMode            bool   `json:"selectedMode"`
+	Animation               bool   `json:"animation"`
+	AnimationThreshold      int    `json:"animationThreshold,omitempty"`
+	AnimationDuration       int    `json:"animationDuration,omitempty"`
+	AnimationEasing         string `json:"animationEasing,omitempty"`
+	AnimationDelay          int    `json:"animationDelay,omitempty"`
+	AnimationDurationUpdate int    `json:"animationDurationUpdate,omitempty"`
+	AnimationEasingUpdate   string `json:"animationEasingUpdate,omitempty"`
+	AnimationDelayUpdate    int    `json:"animationDelayUpdate,omitempty"`
+
 	// series data
 	Data interface{} `json:"data"`
 
 	// series options
 	*opts.ItemStyle    `json:"itemStyle,omitempty"`
 	*opts.Label        `json:"label,omitempty"`
+	*opts.LabelLine    `json:"labelLine,omitempty"`
 	*opts.Emphasis     `json:"emphasis,omitempty"`
 	*opts.MarkLines    `json:"markLine,omitempty"`
 	*opts.MarkPoints   `json:"markPoint,omitempty"`
@@ -121,6 +136,23 @@ func WithBarChartOpts(opt opts.BarChart) SeriesOpts {
 		s.BarCategoryGap = opt.BarCategoryGap
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex
+	}
+}
+
+func WithSunburstOpts(opt opts.SunburstChart) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.NodeClick = opt.NodeClick
+		s.Sort = opt.Sort
+		s.RenderLabelForZeroData = opt.RenderLabelForZeroData
+		s.SelectedMode = opt.SelectedMode
+		s.Animation = opt.Animation
+		s.AnimationThreshold = opt.AnimationThreshold
+		s.AnimationDuration = opt.AnimationDuration
+		s.AnimationEasing = opt.AnimationEasing
+		s.AnimationDelay = opt.AnimationDelay
+		s.AnimationDurationUpdate = opt.AnimationDurationUpdate
+		s.AnimationEasingUpdate = opt.AnimationEasingUpdate
+		s.AnimationDelayUpdate = opt.AnimationDelayUpdate
 	}
 }
 

--- a/charts/sunburst.go
+++ b/charts/sunburst.go
@@ -12,7 +12,7 @@ type Sunburst struct {
 }
 
 // Type returns the chart type.
-func (Sunburst) Type() string { return types.Sunburst }
+func (Sunburst) Type() string { return types.ChartSunburst }
 
 // NewSunburst creates a new sunburst chart instance.
 func NewSunburst() *Sunburst {
@@ -23,7 +23,7 @@ func NewSunburst() *Sunburst {
 }
 
 func (c *Sunburst) AddSeries(name string, data []opts.SunBurstData, options ...SeriesOpts) *Sunburst {
-	series := SingleSeries{Name: name, Type: types.Sunburst, Data: data}
+	series := SingleSeries{Name: name, Type: types.ChartSunburst, Data: data}
 	series.configureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c

--- a/charts/sunburst.go
+++ b/charts/sunburst.go
@@ -8,7 +8,7 @@ import (
 
 // Sunburst represents a sunburst chart.
 type Sunburst struct {
-	RectChart
+	BaseConfiguration
 }
 
 // Type returns the chart type.
@@ -22,10 +22,17 @@ func NewSunburst() *Sunburst {
 	return c
 }
 
+// AddSeries adds new data sets.
 func (c *Sunburst) AddSeries(name string, data []opts.SunBurstData, options ...SeriesOpts) *Sunburst {
 	series := SingleSeries{Name: name, Type: types.ChartSunburst, Data: data}
 	series.configureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
+	return c
+}
+
+// SetGlobalOptions sets options for the Pie instance.
+func (c *Sunburst) SetGlobalOptions(options ...GlobalOpts) *Sunburst {
+	c.BaseConfiguration.setBaseGlobalOptions(options...)
 	return c
 }
 

--- a/charts/sunburst.go
+++ b/charts/sunburst.go
@@ -1,0 +1,35 @@
+package charts
+
+import (
+	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/go-echarts/go-echarts/v2/render"
+	"github.com/go-echarts/go-echarts/v2/types"
+)
+
+// Sunburst represents a sunburst chart.
+type Sunburst struct {
+	RectChart
+}
+
+// Type returns the chart type.
+func (Sunburst) Type() string { return types.Sunburst }
+
+// NewSunburst creates a new sunburst chart instance.
+func NewSunburst() *Sunburst {
+	c := &Sunburst{}
+	c.initBaseConfiguration()
+	c.Renderer = render.NewChartRender(c, c.Validate)
+	return c
+}
+
+func (c *Sunburst) AddSeries(name string, data []opts.SunBurstData, options ...SeriesOpts) *Sunburst {
+	series := SingleSeries{Name: name, Type: types.Sunburst, Data: data}
+	series.configureSeriesOpts(options...)
+	c.MultiSeries = append(c.MultiSeries, series)
+	return c
+}
+
+// Validate validates the given configuration.
+func (c *Sunburst) Validate() {
+	c.Assets.Validate(c.AssetsHost)
+}

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -35,19 +35,33 @@ type BarChart struct {
 	CoordSystem    string
 }
 
+// SunburstChart
+// https://echarts.apache.org/en/option.html#series-sunburst
 type SunburstChart struct {
-	NodeClick               string `json:"nodeClick,omitempty"`
-	Sort                    string `json:"sort,omitempty"`
-	RenderLabelForZeroData  bool   `json:"renderLabelForZeroData"`
-	SelectedMode            bool   `json:"selectedMode"`
-	Animation               bool   `json:"animation"`
-	AnimationThreshold      int    `json:"animationThreshold,omitempty"`
-	AnimationDuration       int    `json:"animationDuration,omitempty"`
-	AnimationEasing         string `json:"animationEasing,omitempty"`
-	AnimationDelay          int    `json:"animationDelay,omitempty"`
-	AnimationDurationUpdate int    `json:"animationDurationUpdate,omitempty"`
-	AnimationEasingUpdate   string `json:"animationEasingUpdate,omitempty"`
-	AnimationDelayUpdate    int    `json:"animationDelayUpdate,omitempty"`
+	// The action of clicking a sector
+	NodeClick string `json:"nodeClick,omitempty"`
+	// Sorting method that sectors use based on value
+	Sort string `json:"sort,omitempty"`
+	// If there is no name, whether need to render it.
+	RenderLabelForZeroData bool `json:"renderLabelForZeroData"`
+	// Selected mode
+	SelectedMode bool `json:"selectedMode"`
+	// Whether to enable animation.
+	Animation bool `json:"animation"`
+	// Whether to set graphic number threshold to animation
+	AnimationThreshold int `json:"animationThreshold,omitempty"`
+	// Duration of the first animation
+	AnimationDuration int `json:"animationDuration,omitempty"`
+	// Easing method used for the first animation
+	AnimationEasing string `json:"animationEasing,omitempty"`
+	// Delay before updating the first animation
+	AnimationDelay int `json:"animationDelay,omitempty"`
+	// Time for animation to complete
+	AnimationDurationUpdate int `json:"animationDurationUpdate,omitempty"`
+	// Easing method used for animation.
+	AnimationEasingUpdate string `json:"animationEasingUpdate,omitempty"`
+	// Delay before updating animation
+	AnimationDelayUpdate int `json:"animationDelayUpdate,omitempty"`
 }
 
 // BarData
@@ -534,7 +548,10 @@ type Chart3DData struct {
 
 // SunBurstData data
 type SunBurstData struct {
-	Name     string          `json:"name,omitempty"`
-	Value    float64         `json:"value,omitempty"`
+	// Name of data item.
+	Name string `json:"name,omitempty"`
+	// Value of data item.
+	Value float64 `json:"value,omitempty"`
+	// sub item of data item
 	Children []*SunBurstData `json:"children,omitempty"`
 }

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -30,6 +30,21 @@ type BarChart struct {
 	YAxisIndex int
 }
 
+type SunburstChart struct {
+	NodeClick               string `json:"nodeClick,omitempty"`
+	Sort                    string `json:"sort,omitempty"`
+	RenderLabelForZeroData  bool   `json:"renderLabelForZeroData"`
+	SelectedMode            bool   `json:"selectedMode"`
+	Animation               bool   `json:"animation"`
+	AnimationThreshold      int    `json:"animationThreshold,omitempty"`
+	AnimationDuration       int    `json:"animationDuration,omitempty"`
+	AnimationEasing         string `json:"animationEasing,omitempty"`
+	AnimationDelay          int    `json:"animationDelay,omitempty"`
+	AnimationDurationUpdate int    `json:"animationDurationUpdate,omitempty"`
+	AnimationEasingUpdate   string `json:"animationEasingUpdate,omitempty"`
+	AnimationDelayUpdate    int    `json:"animationDelayUpdate,omitempty"`
+}
+
 // BarData
 // https://echarts.apache.org/en/option.html#series-bar.data
 type BarData struct {
@@ -510,4 +525,11 @@ type Chart3DData struct {
 
 	// The style setting of the text label in a single bar.
 	Label *Label `json:"label,omitempty"`
+}
+
+// SunBurstData data
+type SunBurstData struct {
+	Name     string          `json:"name,omitempty"`
+	Value    float64         `json:"value,omitempty"`
+	Children []*SunBurstData `json:"children,omitempty"`
 }

--- a/opts/global.go
+++ b/opts/global.go
@@ -456,6 +456,13 @@ type AxisLabel struct {
 	// Set this to false to prevent the axis label from appearing.
 	Show bool `json:"show,omitempty"`
 
+	// Interval of Axis label, which is available in category axis.
+	// It uses a strategy that labels do not overlap by default.
+	// You may set it to be 0 to display all labels compulsively.
+	// If it is set to be 1, it means that labels are shown once after one label.
+	// And if it is set to be 2, it means labels are shown once after two labels, and so on.
+	Interval string `json:"interval,omitempty"`
+
 	// Set this to true so the axis labels face the inside direction.
 	Inside bool `json:"inside,omitempty"`
 
@@ -465,13 +472,6 @@ type AxisLabel struct {
 
 	// The margin between the axis label and the axis line.
 	Margin float64 `json:"margin,omitempty"`
-
-	// Interval of Axis label, which is available in category axis.
-	// It uses a strategy that labels do not overlap by default.
-	// You may set it to be 0 to display all labels compulsively.
-	// If it is set to be 1, it means that labels are shown once after one label.
-	// And if it is set to be 2, it means labels are shown once after two labels, and so on.
-	Interval string `json:"interval,omitempty"`
 
 	// Formatter of axis label, which supports string template and callback function.
 	//
@@ -494,6 +494,9 @@ type AxisLabel struct {
 	//}
 	Formatter string `json:"formatter,omitempty"`
 
+	ShowMinLabel bool `json:"showMinLabel"`
+	ShowMaxLabel bool `json:"showMaxLabel"`
+
 	// Color of axis label is set to be axisLine.lineStyle.color by default. Callback function is supported,
 	// in the following format:
 	//
@@ -506,6 +509,14 @@ type AxisLabel struct {
 	//    }
 	// }
 	Color string `json:"color,omitempty"`
+
+	FontStyle     string `json:"fontStyle,omitempty"`
+	FontWeight    string `json:"fontWeight,omitempty"`
+	FontFamily    string `json:"fontFamily,omitempty"`
+	FontSize      string `json:"fontSize,omitempty"`
+	Align         string `json:"align,omitempty"`
+	VerticalAlign string `json:"verticalAlign,omitempty"`
+	LineHeight    string `json:"lineHeight,omitempty"`
 }
 
 // XAxis is the option set for X axis.

--- a/opts/global.go
+++ b/opts/global.go
@@ -531,13 +531,20 @@ type AxisLabel struct {
 	// }
 	Color string `json:"color,omitempty"`
 
-	FontStyle     string `json:"fontStyle,omitempty"`
-	FontWeight    string `json:"fontWeight,omitempty"`
-	FontFamily    string `json:"fontFamily,omitempty"`
-	FontSize      string `json:"fontSize,omitempty"`
-	Align         string `json:"align,omitempty"`
+	// axis label font style
+	FontStyle string `json:"fontStyle,omitempty"`
+	// axis label font weight
+	FontWeight string `json:"fontWeight,omitempty"`
+	// axis label font family
+	FontFamily string `json:"fontFamily,omitempty"`
+	// axis label font size
+	FontSize string `json:"fontSize,omitempty"`
+	// Horizontal alignment of axis label
+	Align string `json:"align,omitempty"`
+	// Vertical alignment of axis label
 	VerticalAlign string `json:"verticalAlign,omitempty"`
-	LineHeight    string `json:"lineHeight,omitempty"`
+	// Line height of the axis label
+	LineHeight string `json:"lineHeight,omitempty"`
 }
 
 // XAxis is the option set for X axis.

--- a/opts/series.go
+++ b/opts/series.go
@@ -6,7 +6,7 @@ import "fmt"
 // https://echarts.apache.org/en/option.html#series-line.label
 type Label struct {
 	// Whether to show label.
-	Show bool `json:"show,omitempty"`
+	Show bool `json:"show"`
 
 	// Color is the text color.
 	// If set as "auto", the color will assigned as visual color, such as series color.
@@ -46,6 +46,15 @@ type Label struct {
 	// {@xxx}: the value of a dimension named"xxx", for example,{@product}refers the value of"product"` dimension.
 	// {@[n]}: the value of a dimension at the index ofn, for example,{@[3]}` refers the value at dimensions[3].
 	Formatter string `json:"formatter,omitempty"`
+}
+
+type LabelLine struct {
+	Show         bool    `json:"show"`
+	ShowAbove    bool    `json:"showAbove"`
+	Length2      float64 `json:"length2,omitempty"`
+	Smooth       bool    `json:"smooth"`
+	MinTurnAngle float64 `json:"minTurnAngle,omitempty"`
+	LineStyle
 }
 
 // Emphasis is the style when it is highlighted, like being hovered by mouse, or highlighted via legend connect.

--- a/opts/series.go
+++ b/opts/series.go
@@ -48,13 +48,20 @@ type Label struct {
 	Formatter string `json:"formatter,omitempty"`
 }
 
+// LabelLine Configuration of label guide line.
 type LabelLine struct {
-	Show         bool    `json:"show"`
-	ShowAbove    bool    `json:"showAbove"`
-	Length2      float64 `json:"length2,omitempty"`
-	Smooth       bool    `json:"smooth"`
+	// Whether to show the label guide line.
+	Show bool `json:"show"`
+	// Whether to show the label guide line above the corresponding element.
+	ShowAbove bool `json:"showAbove"`
+	// The length of the second segment of guide line.
+	Length2 float64 `json:"length2,omitempty"`
+	// smoothness of guide line.
+	Smooth bool `json:"smooth"`
+	// Minimum turn angle between two segments of guide line
 	MinTurnAngle float64 `json:"minTurnAngle,omitempty"`
-	LineStyle
+	// The style of label line
+	LineStyle *LineStyle `json:"lineStyle,omitempty"`
 }
 
 // Emphasis is the style when it is highlighted, like being hovered by mouse, or highlighted via legend connect.

--- a/types/charts.go
+++ b/types/charts.go
@@ -26,4 +26,5 @@ const (
 	ChartSurface3D     = "surface"
 	ChartThemeRiver    = "themeRiver"
 	ChartWordCloud     = "wordCloud"
+	Sunburst           = "sunburst"
 )

--- a/types/charts.go
+++ b/types/charts.go
@@ -26,5 +26,5 @@ const (
 	ChartSurface3D     = "surface"
 	ChartThemeRiver    = "themeRiver"
 	ChartWordCloud     = "wordCloud"
-	Sunburst           = "sunburst"
+	ChartSunburst      = "sunburst"
 )


### PR DESCRIPTION
## Sunburst
<img width="458" alt="Screen Shot 2021-02-07 at 23 53 15" src="https://user-images.githubusercontent.com/20318608/107151827-b3ab5a00-699f-11eb-8f4e-0cde62f2151d.png">

## API
- `WithSunburstOpts `
- `NewSunburst`

## Example
```go
package main

import (
	"math/rand"
	"os"

	"github.com/go-echarts/go-echarts/v2/charts"
	"github.com/go-echarts/go-echarts/v2/opts"
)

// generate random data for bar chart
func generateBarItems() []opts.SunBurstData {
	items := make([]opts.SunBurstData, 0)
	for i := 0; i < 7; i++ {
		items = append(items, opts.SunBurstData{
			Value: rand.Float64(),
			Name:  "11111",
			Children: []*opts.SunBurstData{
				{
					Value: rand.Float64(),
					Name:  "2222",
				},
			},
		})
	}
	return items
}

func main() {
	sunburst := charts.NewSunburst()
	sunburst.SetGlobalOptions(
		charts.WithTitleOpts((opts.Title{Title: "Sunburst"})),
	)
	sunburst.AddSeries("sunburst", generateBarItems()).SetSeriesOptions(
		charts.WithLabelOpts(
			opts.Label{
				Show:      true,
				Formatter: "12345s",
			},
		),
		charts.WithSunburstOpts(
			opts.SunburstChart{
				Animation: false,
			},
		),
	)
	// Where the magic happens
	f, _ := os.Create("test.html")
	sunburst.Render(f)
}
```

## PS
It's better to not `omitempty` for `bool` type, because `Apache ECharts` has default for some nullish option. In that case, if user set `false`, option would be omitted, `echarts` would receive `true`, that against user wish.  