### PR TITLE
Feat/tree linestyle

### DIFF
--- a/charts/tree.go
+++ b/charts/tree.go
@@ -29,6 +29,12 @@ func (c *Tree) AddSeries(name string, data []opts.TreeData, options ...SeriesOpt
 	return c
 }
 
+// SetGlobalOptions sets options for the Graph instance.
+func (c *Tree) SetGlobalOptions(options ...GlobalOpts) *Tree {
+	c.BaseConfiguration.setBaseGlobalOptions(options...)
+	return c
+}
+
 // Validate validates the given configuration.
 func (c *Tree) Validate() {
 	c.Assets.Validate(c.AssetsHost)

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -608,6 +608,12 @@ type TreeData struct {
 
 	// If set as `true`, the node is collpased in the initialization.
 	Collapsed bool `json:"collapsed,omitempty"`
+
+	// LineStyle settings in this series data.
+	LineStyle *LineStyle `json:"lineStyle,omitempty"`
+
+	// ItemStyle settings in this series data.
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 }
 
 // SunBurstData data

--- a/opts/series.go
+++ b/opts/series.go
@@ -305,6 +305,9 @@ type TreeLeaves struct {
 	// The style setting of the text label in a single bar.
 	Label *Label `json:"label,omitempty"`
 
+	// LineStyle settings in this series data.
+	LineStyle *LineStyle `json:"lineStyle,omitempty"`
+
 	// ItemStyle settings in this series data.
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 


### PR DESCRIPTION
Add option to customize node and item style

Fix missing SetGlobalOptions function from https://github.com/go-echarts/go-echarts/pull/159