### PR TITLE
Bar3D struct should produce Bar3D charts

### DIFF
--- a/charts/bar3d.go
+++ b/charts/bar3d.go
@@ -25,6 +25,6 @@ func NewBar3D() *Bar3D {
 
 // AddSeries adds the new series.
 func (c *Bar3D) AddSeries(name string, data []opts.Chart3DData, options ...SeriesOpts) *Bar3D {
-	c.addSeries(types.ChartScatter3D, name, data, options...)
+	c.addSeries(types.ChartBar3D, name, data, options...)
 	return c
 }


### PR DESCRIPTION
Fixed typo that was causing Bar3D struct to render Scatter3D charts.