### PR TITLE
Add ShowSymbol option for line

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -36,6 +36,7 @@ type SingleSeries struct {
 	Step         bool `json:"step,omitempty"`
 	Smooth       bool `json:"smooth,omitempty"`
 	ConnectNulls bool `json:"connectNulls,omitempty"`
+	ShowSymbol   bool `json:"showSymbol"`
 
 	// Liquid
 	IsLiquidOutline bool `json:"outline,omitempty"`

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -318,6 +318,9 @@ type LineChart struct {
 
 	// Whether to connect the line across null points.
 	ConnectNulls bool
+
+	// Whether to show symbol. It would be shown during tooltip hover.
+	ShowSymbol bool
 }
 
 // LineData


### PR DESCRIPTION
https://echarts.apache.org/en/option.html#series-line.showSymbol

 Allow configure showSymbol to hide markers in line charts.
