### PR TITLE
Refactor incomplete comments of exported functions

### DIFF
--- a/charts/bar.go
+++ b/charts/bar.go
@@ -25,7 +25,7 @@ func NewBar() *Bar {
 	return c
 }
 
-// EnablePolarType enable polar bar
+// EnablePolarType enables the polar bar.
 func (c *Bar) EnablePolarType() *Bar {
 	c.hasXYAxis = false
 	c.hasPolar = true

--- a/charts/base.go
+++ b/charts/base.go
@@ -128,7 +128,7 @@ func (bc *BaseConfiguration) JSON() map[string]interface{} {
 	return obj
 }
 
-// GetAssets returns the Assets options
+// GetAssets returns the Assets options.
 func (bc *BaseConfiguration) GetAssets() opts.Assets {
 	return bc.Assets
 }
@@ -162,63 +162,63 @@ func (bc *BaseConfiguration) setBaseGlobalOptions(opts ...GlobalOpts) {
 	}
 }
 
-// WithPolarOps set angleAxis
+// WithAngleAxisOps sets the angle of the axis.
 func WithAngleAxisOps(opt opts.AngleAxis) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.AngleAxis = opt
 	}
 }
 
-// WithPolarOps set radiusAxis
+// WithRadiusAxisOps sets the radius of the axis.
 func WithRadiusAxisOps(opt opts.RadiusAxis) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.RadiusAxis = opt
 	}
 }
 
-// WithPolarOps set polar
+// WithPolarOps sets the polar.
 func WithPolarOps(opt opts.Polar) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Polar = opt
 	}
 }
 
-// WithTitleOpts
+// WithTitleOpts sets the title.
 func WithTitleOpts(opt opts.Title) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Title = opt
 	}
 }
 
-// WithToolboxOpts
+// WithToolboxOpts sets the toolbox.
 func WithToolboxOpts(opt opts.Toolbox) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Toolbox = opt
 	}
 }
 
-// WithSingleAxisOpts
+// WithSingleAxisOpts sets the single axis.
 func WithSingleAxisOpts(opt opts.SingleAxis) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.SingleAxis = opt
 	}
 }
 
-// WithTooltipOpts
+// WithTooltipOpts sets the tooltip.
 func WithTooltipOpts(opt opts.Tooltip) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Tooltip = opt
 	}
 }
 
-// WithLegendOpts
+// WithLegendOpts sets the legend.
 func WithLegendOpts(opt opts.Legend) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Legend = opt
 	}
 }
 
-// WithInitializationOpts
+// WithInitializationOpts sets the initialization.
 func WithInitializationOpts(opt opts.Initialization) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Initialization = opt
@@ -231,28 +231,28 @@ func WithInitializationOpts(opt opts.Initialization) GlobalOpts {
 	}
 }
 
-// WithDataZoomOpts
+// WithDataZoomOpts sets the list of the zoom data.
 func WithDataZoomOpts(opt ...opts.DataZoom) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.DataZoomList = append(bc.DataZoomList, opt...)
 	}
 }
 
-// WithVisualMapOpts
+// WithVisualMapOpts sets the List of the visual map.
 func WithVisualMapOpts(opt ...opts.VisualMap) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.VisualMapList = append(bc.VisualMapList, opt...)
 	}
 }
 
-// WithRadarComponentOpts
+// WithRadarComponentOpts sets the component of the radar.
 func WithRadarComponentOpts(opt opts.RadarComponent) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.RadarComponent = opt
 	}
 }
 
-// WithGeoComponentOpts
+// WithGeoComponentOpts sets the geo component.
 func WithGeoComponentOpts(opt opts.GeoComponent) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.GeoComponent = opt
@@ -261,28 +261,28 @@ func WithGeoComponentOpts(opt opts.GeoComponent) GlobalOpts {
 
 }
 
-// WithParallelComponentOpts
+// WithParallelComponentOpts sets the parallel component.
 func WithParallelComponentOpts(opt opts.ParallelComponent) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.ParallelComponent = opt
 	}
 }
 
-// WithParallelAxisList
+// WithParallelAxisList sets the list of the parallel axis.
 func WithParallelAxisList(opt []opts.ParallelAxis) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.ParallelAxisList = opt
 	}
 }
 
-// WithColorsOpts
+// WithColorsOpts sets the color.
 func WithColorsOpts(opt opts.Colors) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.insertSeriesColors(opt)
 	}
 }
 
-// reverseSlice reverse string slice
+// reverseSlice reverses the string slice.
 func reverseSlice(s []string) []string {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]

--- a/charts/chart3d.go
+++ b/charts/chart3d.go
@@ -10,28 +10,28 @@ type Chart3D struct {
 	BaseConfiguration
 }
 
-// WithXAxis3DOpts
+// WithXAxis3DOpts sets the X axis of the Chart3D instance.
 func WithXAxis3DOpts(opt opts.XAxis3D) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.XAxis3D = opt
 	}
 }
 
-// WithYAxis3DOpts
+// WithYAxis3DOpts sets the Y axis of the Chart3D instance.
 func WithYAxis3DOpts(opt opts.YAxis3D) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.YAxis3D = opt
 	}
 }
 
-// WithZAxis3DOpts
+// WithZAxis3DOpts sets the Z axis of the Chart3D instance.
 func WithZAxis3DOpts(opt opts.ZAxis3D) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.ZAxis3D = opt
 	}
 }
 
-// WithGrid3DOpts
+// WithGrid3DOpts sets the grid of the Chart3D instance.
 func WithGrid3DOpts(opt opts.Grid3D) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Grid3D = opt
@@ -60,7 +60,7 @@ func (c *Chart3D) SetGlobalOptions(options ...GlobalOpts) *Chart3D {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Chart3D) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/funnel.go
+++ b/charts/funnel.go
@@ -36,7 +36,7 @@ func (c *Funnel) SetGlobalOptions(options ...GlobalOpts) *Funnel {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Funnel) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/gauge.go
+++ b/charts/gauge.go
@@ -36,7 +36,7 @@ func (c *Gauge) SetGlobalOptions(options ...GlobalOpts) *Gauge {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Gauge) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/geo.go
+++ b/charts/geo.go
@@ -59,7 +59,7 @@ func (c *Geo) SetGlobalOptions(options ...GlobalOpts) *Geo {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Geo) Validate() {
 	if c.Tooltip.Formatter == "" {
 		c.Tooltip.Formatter = opts.FuncOpts(geoFormatter)

--- a/charts/heatmap.go
+++ b/charts/heatmap.go
@@ -37,7 +37,7 @@ func (c *HeatMap) AddSeries(name string, data []opts.HeatMapData, options ...Ser
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *HeatMap) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/kline.go
+++ b/charts/kline.go
@@ -37,7 +37,7 @@ func (c *Kline) AddSeries(name string, data []opts.KlineData, options ...SeriesO
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Kline) Validate() {
 	c.XAxisList[0].Data = c.xAxisData
 	c.Assets.Validate(c.AssetsHost)

--- a/charts/liquid.go
+++ b/charts/liquid.go
@@ -37,7 +37,7 @@ func (c *Liquid) SetGlobalOptions(options ...GlobalOpts) *Liquid {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Liquid) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/map.go
+++ b/charts/map.go
@@ -25,7 +25,7 @@ func NewMap() *Map {
 	return c
 }
 
-// RegisterMapType
+// RegisterMapType registers the given mapType.
 func (c *Map) RegisterMapType(mapType string) {
 	c.mapType = mapType
 	c.JSAssets.Add("maps/" + datasets.MapFileNames[mapType] + ".js")
@@ -45,7 +45,7 @@ func (c *Map) SetGlobalOptions(options ...GlobalOpts) *Map {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Map) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/parallel.go
+++ b/charts/parallel.go
@@ -37,7 +37,7 @@ func (c *Parallel) SetGlobalOptions(options ...GlobalOpts) *Parallel {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Parallel) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/pie.go
+++ b/charts/pie.go
@@ -36,7 +36,7 @@ func (c *Pie) SetGlobalOptions(options ...GlobalOpts) *Pie {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Pie) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/radar.go
+++ b/charts/radar.go
@@ -38,7 +38,7 @@ func (c *Radar) SetGlobalOptions(options ...GlobalOpts) *Radar {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Radar) Validate() {
 	c.Legend.Data = c.legends
 	c.Assets.Validate(c.AssetsHost)

--- a/charts/rectangle.go
+++ b/charts/rectangle.go
@@ -29,7 +29,7 @@ func (xy *XYAxis) ExtendYAxis(yAxis ...opts.YAxis) {
 	xy.YAxisList = append(xy.YAxisList, yAxis...)
 }
 
-// WithXAxisOpts
+// WithXAxisOpts sets the X axis.
 func WithXAxisOpts(opt opts.XAxis, index ...int) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		if len(index) == 0 {
@@ -41,7 +41,7 @@ func WithXAxisOpts(opt opts.XAxis, index ...int) GlobalOpts {
 	}
 }
 
-// WithYAxisOpts
+// WithYAxisOpts sets the Y axis.
 func WithYAxisOpts(opt opts.YAxis, index ...int) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		if len(index) == 0 {
@@ -88,7 +88,7 @@ func (rc *RectChart) Overlap(a ...Overlaper) {
 	}
 }
 
-// Validate
+// Validate validates the given configuration.
 func (rc *RectChart) Validate() {
 	// Make sure that the data of X axis won't be cleaned for XAxisOpts
 	rc.XAxisList[0].Data = rc.xAxisData

--- a/charts/sankey.go
+++ b/charts/sankey.go
@@ -36,7 +36,7 @@ func (c *Sankey) SetGlobalOptions(options ...GlobalOpts) *Sankey {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *Sankey) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/series.go
+++ b/charts/series.go
@@ -101,42 +101,42 @@ type SingleSeries struct {
 
 type SeriesOpts func(s *SingleSeries)
 
-// WithLabelOpts
+// WithLabelOpts sets the label.
 func WithLabelOpts(opt opts.Label) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Label = &opt
 	}
 }
 
-// WithEmphasisOpts
+// WithEmphasisOpts sets the emphasis.
 func WithEmphasisOpts(opt opts.Emphasis) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Emphasis = &opt
 	}
 }
 
-// WithAreaStyleOpts
+// WithAreaStyleOpts sets the area style.
 func WithAreaStyleOpts(opt opts.AreaStyle) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.AreaStyle = &opt
 	}
 }
 
-// WithItemStyleOpts
+// WithItemStyleOpts sets the item style.
 func WithItemStyleOpts(opt opts.ItemStyle) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.ItemStyle = &opt
 	}
 }
 
-// WithRippleEffectOpts
+// WithRippleEffectOpts sets the ripple effect.
 func WithRippleEffectOpts(opt opts.RippleEffect) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.RippleEffect = &opt
 	}
 }
 
-// WithLineStyleOpts
+// WithLineStyleOpts sets the line style.
 func WithLineStyleOpts(opt opts.LineStyle) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.LineStyle = &opt
@@ -145,7 +145,7 @@ func WithLineStyleOpts(opt opts.LineStyle) SeriesOpts {
 
 /* Chart Options */
 
-// WithBarChartOpts
+// WithBarChartOpts sets the BarChart option.
 func WithBarChartOpts(opt opts.BarChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Stack = opt.Stack
@@ -160,6 +160,7 @@ func WithBarChartOpts(opt opts.BarChart) SeriesOpts {
 	}
 }
 
+// WithSunburstOpts sets the SunburstChart option.
 func WithSunburstOpts(opt opts.SunburstChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.NodeClick = opt.NodeClick
@@ -177,7 +178,7 @@ func WithSunburstOpts(opt opts.SunburstChart) SeriesOpts {
 	}
 }
 
-// WithGraphChartOpts
+// WithGraphChartOpts sets the GraphChart option.
 func WithGraphChartOpts(opt opts.GraphChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Layout = opt.Layout
@@ -192,7 +193,7 @@ func WithGraphChartOpts(opt opts.GraphChart) SeriesOpts {
 	}
 }
 
-// WithHeatMapChartOpts
+// WithHeatMapChartOpts sets the HeatMapChart option.
 func WithHeatMapChartOpts(opt opts.HeatMapChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.XAxisIndex = opt.XAxisIndex
@@ -200,7 +201,7 @@ func WithHeatMapChartOpts(opt opts.HeatMapChart) SeriesOpts {
 	}
 }
 
-// WithLineChartOpts
+// WithLineChartOpts sets the LineChart option.
 func WithLineChartOpts(opt opts.LineChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.YAxisIndex = opt.YAxisIndex
@@ -213,7 +214,7 @@ func WithLineChartOpts(opt opts.LineChart) SeriesOpts {
 	}
 }
 
-// WithPieChartOpts
+// WithPieChartOpts sets the PieChart option.
 func WithPieChartOpts(opt opts.PieChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.RoseType = opt.RoseType
@@ -222,7 +223,7 @@ func WithPieChartOpts(opt opts.PieChart) SeriesOpts {
 	}
 }
 
-// WithScatterChartOpts
+// WithScatterChartOpts sets the ScatterChart option.
 func WithScatterChartOpts(opt opts.ScatterChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.XAxisIndex = opt.XAxisIndex
@@ -230,7 +231,7 @@ func WithScatterChartOpts(opt opts.ScatterChart) SeriesOpts {
 	}
 }
 
-// WithLiquidChartOpts
+// WithLiquidChartOpts sets the LiquidChart option.
 func WithLiquidChartOpts(opt opts.LiquidChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Shape = opt.Shape
@@ -239,14 +240,14 @@ func WithLiquidChartOpts(opt opts.LiquidChart) SeriesOpts {
 	}
 }
 
-// WithBar3DChartOpts
+// WithBar3DChartOpts sets the Bar3DChart option.
 func WithBar3DChartOpts(opt opts.Bar3DChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Shading = opt.Shading
 	}
 }
 
-// WithTreeOpts
+// WithTreeOpts sets the TreeChart option.
 func WithTreeOpts(opt opts.TreeChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Layout = opt.Layout
@@ -263,7 +264,7 @@ func WithTreeOpts(opt opts.TreeChart) SeriesOpts {
 	}
 }
 
-// WithWorldCloudChartOpts
+// WithWorldCloudChartOpts sets the WorldCloudChart option.
 func WithWorldCloudChartOpts(opt opts.WordCloudChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Shape = opt.Shape
@@ -272,7 +273,7 @@ func WithWorldCloudChartOpts(opt opts.WordCloudChart) SeriesOpts {
 	}
 }
 
-// WithMarkLineNameTypeItemOpts
+// WithMarkLineNameTypeItemOpts sets the type of the MarkLine.
 func WithMarkLineNameTypeItemOpts(opt ...opts.MarkLineNameTypeItem) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkLines == nil {
@@ -284,7 +285,7 @@ func WithMarkLineNameTypeItemOpts(opt ...opts.MarkLineNameTypeItem) SeriesOpts {
 	}
 }
 
-// WithMarkLineStyleOpts
+// WithMarkLineStyleOpts sets the style of the MarkLine.
 func WithMarkLineStyleOpts(opt opts.MarkLineStyle) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkLines == nil {
@@ -295,7 +296,7 @@ func WithMarkLineStyleOpts(opt opts.MarkLineStyle) SeriesOpts {
 	}
 }
 
-// WithMarkLineNameCoordItemOpts
+// WithMarkLineNameCoordItemOpts sets the coordinates of the MarkLine.
 func WithMarkLineNameCoordItemOpts(opt ...opts.MarkLineNameCoordItem) SeriesOpts {
 	type MLNameCoord struct {
 		Name  string        `json:"name,omitempty"`
@@ -311,7 +312,7 @@ func WithMarkLineNameCoordItemOpts(opt ...opts.MarkLineNameCoordItem) SeriesOpts
 	}
 }
 
-// WithMarkLineNameXAxisItemOpts
+// WithMarkLineNameXAxisItemOpts sets the X axis of the MarkLine.
 func WithMarkLineNameXAxisItemOpts(opt ...opts.MarkLineNameXAxisItem) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkLines == nil {
@@ -323,7 +324,7 @@ func WithMarkLineNameXAxisItemOpts(opt ...opts.MarkLineNameXAxisItem) SeriesOpts
 	}
 }
 
-// WithMarkLineNameYAxisItemOpts
+// WithMarkLineNameYAxisItemOpts sets the Y axis of the MarkLine.
 func WithMarkLineNameYAxisItemOpts(opt ...opts.MarkLineNameYAxisItem) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkLines == nil {
@@ -335,7 +336,7 @@ func WithMarkLineNameYAxisItemOpts(opt ...opts.MarkLineNameYAxisItem) SeriesOpts
 	}
 }
 
-// WithMarkPointNameTypeItemOpts
+// WithMarkPointNameTypeItemOpts sets the type of the MarkPoint.
 func WithMarkPointNameTypeItemOpts(opt ...opts.MarkPointNameTypeItem) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkPoints == nil {
@@ -347,7 +348,7 @@ func WithMarkPointNameTypeItemOpts(opt ...opts.MarkPointNameTypeItem) SeriesOpts
 	}
 }
 
-// WithMarkPointStyleOpts
+// WithMarkPointStyleOpts sets the style of the MarkPoint.
 func WithMarkPointStyleOpts(opt opts.MarkPointStyle) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkPoints == nil {
@@ -358,7 +359,7 @@ func WithMarkPointStyleOpts(opt opts.MarkPointStyle) SeriesOpts {
 	}
 }
 
-// WithMarkPointNameCoordItemOpts
+// WithMarkPointNameCoordItemOpts sets the coordinated of the MarkPoint.
 func WithMarkPointNameCoordItemOpts(opt ...opts.MarkPointNameCoordItem) SeriesOpts {
 	return func(s *SingleSeries) {
 		if s.MarkPoints == nil {

--- a/charts/themeriver.go
+++ b/charts/themeriver.go
@@ -41,7 +41,7 @@ func (c *ThemeRiver) SetGlobalOptions(options ...GlobalOpts) *ThemeRiver {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *ThemeRiver) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/charts/tree.go
+++ b/charts/tree.go
@@ -22,6 +22,7 @@ func NewTree() *Tree {
 	return c
 }
 
+// AddSeries adds new data sets.
 func (c *Tree) AddSeries(name string, data []opts.TreeData, options ...SeriesOpts) *Tree {
 	series := SingleSeries{Name: name, Type: types.ChartTree, Data: data}
 	series.configureSeriesOpts(options...)

--- a/charts/wordcloud.go
+++ b/charts/wordcloud.go
@@ -53,7 +53,7 @@ func (c *WordCloud) SetGlobalOptions(options ...GlobalOpts) *WordCloud {
 	return c
 }
 
-// Validate
+// Validate validates the given configuration.
 func (c *WordCloud) Validate() {
 	c.Assets.Validate(c.AssetsHost)
 }

--- a/components/page.go
+++ b/components/page.go
@@ -13,7 +13,7 @@ const (
 	PageFlexLayout   Layout = "flex"
 )
 
-// Charter
+// Charter represents a chart value which provides its type, assets and can be validated.
 type Charter interface {
 	Type() string
 	GetAssets() opts.Assets
@@ -39,6 +39,7 @@ func NewPage() *Page {
 	return page
 }
 
+// SetLayout sets the layout of the Page.
 func (page *Page) SetLayout(layout Layout) *Page {
 	page.Layout = layout
 	return page
@@ -61,7 +62,7 @@ func (page *Page) AddCharts(charts ...Charter) *Page {
 	return page
 }
 
-// Validate
+// Validate validates the given configuration.
 func (page *Page) Validate() {
 	page.Initialization.Validate()
 	page.Assets.Validate(page.AssetsHost)

--- a/opts/global.go
+++ b/opts/global.go
@@ -147,7 +147,7 @@ type Title struct {
 	// Distance between title component and the right side of the container.
 	// right value can be instant pixel value like 20; it can also be a percentage
 	// value relative to container width like '20%'.
-	//Adaptive by default.
+	// Adaptive by default.
 	Right string `json:"right,omitempty"`
 }
 
@@ -512,7 +512,7 @@ type AxisLabel struct {
 	//        texts.unshift(date.getYear());
 	//    }
 	//    return texts.join('/');
-	//}
+	// }
 	Formatter string `json:"formatter,omitempty"`
 
 	ShowMinLabel bool `json:"showMinLabel"`
@@ -823,7 +823,7 @@ type SingleAxis struct {
 	Left string `json:"left,omitempty"`
 
 	// Distance between grid component and the right side of the container.
-	//right value can be instant pixel value like 20; it can also be a percentage
+	// right value can be instant pixel value like 20; it can also be a percentage
 	// value relative to container width like '20%'.
 	Right string `json:"right,omitempty"`
 
@@ -1024,7 +1024,7 @@ func replaceJsFuncs(fn string) string {
 
 type Colors []string
 
-// AssetsOpts contains options for static assets.
+// Assets contains options for static assets.
 type Assets struct {
 	JSAssets  types.OrderedSet
 	CSSAssets types.OrderedSet

--- a/opts/series.go
+++ b/opts/series.go
@@ -73,7 +73,7 @@ type Emphasis struct {
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 }
 
-// ItemStyle
+// ItemStyle represents a style of an item.
 type ItemStyle struct {
 	// Color of chart
 	// Kline Up candle color
@@ -127,7 +127,7 @@ type MarkLineNameTypeItem struct {
 	ValueDim string `json:"valueDim,omitempty"`
 }
 
-// MarkLineNameYAxisItem
+// MarkLineNameYAxisItem defines a MarkLine on a Y axis.
 type MarkLineNameYAxisItem struct {
 	// Mark line name
 	Name string `json:"name,omitempty"`
@@ -142,7 +142,7 @@ type MarkLineNameYAxisItem struct {
 	ValueDim string `json:"valueDim,omitempty"`
 }
 
-// MarkLineNameXAxisItem
+// MarkLineNameXAxisItem defines a MarkLine on a X axis.
 type MarkLineNameXAxisItem struct {
 	// Mark line name
 	Name string `json:"name,omitempty"`

--- a/render/engine.go
+++ b/render/engine.go
@@ -32,7 +32,7 @@ func NewPageRender(c interface{}, before ...func()) Renderer {
 	return &pageRender{c: c, before: before}
 }
 
-// Render
+// Render renders the page into the given io.Writer.
 func (r *pageRender) Render(w io.Writer) error {
 	for _, fn := range r.before {
 		fn()
@@ -63,7 +63,7 @@ func NewChartRender(c interface{}, before ...func()) Renderer {
 	return &chartRender{c: c, before: before}
 }
 
-// Render
+// Render renders the chart into the given io.Writer.
 func (r *chartRender) Render(w io.Writer) error {
 	for _, fn := range r.before {
 		fn()
@@ -84,7 +84,7 @@ func (r *chartRender) Render(w io.Writer) error {
 	return err
 }
 
-// MustTemplate
+// MustTemplate creates a new template with the given name and parsed contents.
 func MustTemplate(name string, contents []string) *template.Template {
 	tpl := template.Must(template.New(name).Parse(contents[0])).Funcs(template.FuncMap{
 		"safeJS": func(s interface{}) template.JS {


### PR DESCRIPTION
I refactored and completed some unfinished comments. I mainly followed practices mentioned in [Effective Go](https://golang.org/doc/effective_go#commentary):

> All comments should start with a whitespace.
Comments of exported functions should begin with the name being declared.
Comments should be meaningful or they should be removed.

However, please feel free to edit or make any changes you deem necessary.