### PR TITLE
fix an escaping of JS code

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -1,6 +1,10 @@
 package charts
 
 import (
+	"bytes"
+	"encoding/json"
+	"html/template"
+
 	"github.com/go-echarts/go-echarts/v2/datasets"
 	"github.com/go-echarts/go-echarts/v2/opts"
 	"github.com/go-echarts/go-echarts/v2/render"
@@ -63,6 +67,21 @@ type BaseConfiguration struct {
 // Get data in bytes
 // bs, _ : = json.Marshal(bar.JSON())
 func (bc *BaseConfiguration) JSON() map[string]interface{} {
+	return bc.json()
+}
+
+// JSONNotEscaped works like method JSON, but it returns a marshaled object whose characters will not be escaped in the template
+func (bc *BaseConfiguration) JSONNotEscaped() template.HTML {
+	obj := bc.json()
+	buff := bytes.NewBufferString("")
+	enc := json.NewEncoder(buff)
+	enc.SetEscapeHTML(false)
+	enc.Encode(obj)
+
+	return template.HTML(buff.String())
+}
+
+func (bc *BaseConfiguration) json() map[string]interface{} {
 	obj := map[string]interface{}{
 		"title":   bc.Title,
 		"legend":  bc.Legend,

--- a/opts/series.go
+++ b/opts/series.go
@@ -1,6 +1,8 @@
 package opts
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Label contains options for a label text.
 // https://echarts.apache.org/en/option.html#series-line.label

--- a/templates/base.go
+++ b/templates/base.go
@@ -9,7 +9,7 @@ var BaseTpl = `
 <script type="text/javascript">
     "use strict";
     let goecharts_{{ .ChartID | safeJS }} = echarts.init(document.getElementById('{{ .ChartID | safeJS }}'), "{{ .Theme }}");
-    let option_{{ .ChartID | safeJS }} = {{ .JSON }};
+    let option_{{ .ChartID | safeJS }} = {{ .JSONNotEscaped | safeJS }};
     goecharts_{{ .ChartID | safeJS }}.setOption(option_{{ .ChartID | safeJS }});
 
     {{- range .JSFunctions.Fns }}


### PR DESCRIPTION
This change resolves the issue with the formatter.
When we use characters like "&" inside the formatters, they were automatically escaped as HTML and nothing could be done about it. As a result, a code like `if (true && true) { return 'something' }` made HTML invalid.