### PR TITLE
Fixed a non-clickable category on the graph chart

### DIFF
--- a/opts/charts.go
+++ b/opts/charts.go
@@ -222,7 +222,7 @@ type GraphNode struct {
 	Fixed bool `json:"fixed,omitempty"`
 
 	// Index of category which the data item belongs to.
-	Category int `json:"category,omitempty"`
+	Category interface{} `json:"category,omitempty"`
 
 	// Symbol of node of this category.
 	// Icon types provided by ECharts includes


### PR DESCRIPTION
There was a problem, because of the int type of Category field and annotation "omitempty". The zero index was never marshaled in the template as a category.