### PR TITLE
Add support for treemap type graph

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -64,6 +64,11 @@ type SingleSeries struct {
 	Top               string      `json:"top,omitempty"`
 	Bottom            string      `json:"bottom,omitempty"`
 
+	// TreeMap
+	LeafDepth  int         `json:"leafDepth,omitempty"`
+	Levels     interface{} `json:"levels,omitempty"`
+	UpperLabel interface{} `json:"upperLabel,omitempty"`
+
 	// WordCloud
 	Shape         string    `json:"shape,omitempty"`
 	SizeRange     []float32 `json:"sizeRange,omitempty"`
@@ -256,6 +261,21 @@ func WithTreeOpts(opt opts.TreeChart) SeriesOpts {
 		s.Roam = opt.Roam
 		s.Label = opt.Label
 		s.Leaves = opt.Leaves
+		s.Right = opt.Right
+		s.Left = opt.Left
+		s.Top = opt.Top
+		s.Bottom = opt.Bottom
+	}
+}
+
+// WithTreeMapOpts sets the TreeMapChart options.
+func WithTreeMapOpts(opt opts.TreeMapChart) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.Animation = opt.Animation
+		s.LeafDepth = opt.LeafDepth
+		s.Roam = opt.Roam
+		s.Levels = opt.Levels
+		s.UpperLabel = opt.UpperLabel
 		s.Right = opt.Right
 		s.Left = opt.Left
 		s.Top = opt.Top

--- a/charts/treemap.go
+++ b/charts/treemap.go
@@ -1,0 +1,42 @@
+package charts
+
+import (
+	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/go-echarts/go-echarts/v2/render"
+	"github.com/go-echarts/go-echarts/v2/types"
+)
+
+// TreeMap represents a TreeMap chart.
+type TreeMap struct {
+	BaseConfiguration
+}
+
+// Type returns the chart type.
+func (TreeMap) Type() string { return types.ChartTreeMap }
+
+// NewTreeMap creates a new TreeMap chart instance.
+func NewTreeMap() *TreeMap {
+	c := &TreeMap{}
+	c.initBaseConfiguration()
+	c.Renderer = render.NewChartRender(c, c.Validate)
+	return c
+}
+
+// AddSeries adds new data sets.
+func (c *TreeMap) AddSeries(name string, data []opts.TreeMapNode, options ...SeriesOpts) *TreeMap {
+	series := SingleSeries{Name: name, Type: types.ChartTreeMap, Data: data}
+	series.configureSeriesOpts(options...)
+	c.MultiSeries = append(c.MultiSeries, series)
+	return c
+}
+
+// SetGlobalOptions sets options for the Graph instance.
+func (c *TreeMap) SetGlobalOptions(options ...GlobalOpts) *TreeMap {
+	c.BaseConfiguration.setBaseGlobalOptions(options...)
+	return c
+}
+
+// Validate validates the given configuration.
+func (c *TreeMap) Validate() {
+	c.Assets.Validate(c.AssetsHost)
+}

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -642,6 +642,48 @@ type TreeData struct {
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 }
 
+type TreeMapChart struct {
+	// Whether to enable animation.
+	Animation bool `json:"animation"`
+
+	// leafDepth represents how many levels are shown at most. For example, when leafDepth is set to 1, only one level will be shown.
+	// leafDepth is null/undefined by default, which means that "drill down" is disabled.
+	LeafDepth int `json:"leafDeapth,omitempty"`
+
+	// Roam describes whether to enable mouse zooming and translating. false by default.
+	Roam bool `json:"roam"`
+
+	// Label decribes the style of the label in each node.
+	Label *Label `json:"label,omitempty"`
+
+	// UpperLabel is used to specify whether show label when the treemap node has children.
+	UpperLabel *UpperLabel `json:"upperLabel,omitempty"`
+
+	// ColorMappingBy specifies the rule according to which each node obtain color from color list.
+	ColorMappingBy string `json:"colorMappingBy,omitempty"`
+
+	// Levels provide configration for each node level
+	Levels *[]TreeMapLevel `json:"levels,omitempty"`
+
+	// Distance between treemap component and the sides of the container.
+	// value can be instant pixel value like 20;
+	// It can also be a percentage value relative to container width like '20%';
+	Left   string `json:"left,omitempty"`
+	Right  string `json:"right,omitempty"`
+	Top    string `json:"top,omitempty"`
+	Bottom string `json:"bottom,omitempty"`
+}
+
+type TreeMapNode struct {
+	// Name of the tree node item.
+	Name string `json:"name"`
+
+	// Value of the tree node item.
+	Value int `json:"value,omitempty"`
+
+	Children []TreeMapNode `json:"children,omitempty"`
+}
+
 // SunBurstData data
 type SunBurstData struct {
 	// Name of data item.

--- a/opts/series.go
+++ b/opts/series.go
@@ -91,6 +91,15 @@ type ItemStyle struct {
 	// Kline Down candle border color
 	BorderColor0 string `json:"borderColor0,omitempty"`
 
+	// Color saturation of a border or gap.
+	BorderColorSaturation float32 `json:"borderColorSaturation,omitempty"`
+
+	// Border width of a node
+	BorderWidth float32 `json:"borderWidth,omitempty"`
+
+	// Gaps between child nodes.
+	GapWidth float32 `json:"gapWidth,omitempty"`
+
 	// Opacity of the component. Supports value from 0 to 1, and the component will not be drawn when set to 0.
 	Opacity float32 `json:"opacity,omitempty"`
 }
@@ -318,6 +327,118 @@ type TreeLeaves struct {
 
 	// Emphasis settings in this series data.
 	Emphasis *Emphasis `json:"emphasis,omitempty"`
+}
+
+// TreeMapLevel is level specific configuration.
+type TreeMapLevel struct {
+	// Color defines a list for a node level, if empty, retreived from global color list.
+	Color []string `json:"color,omitempty"`
+
+	// ColorAlpha indicates the range of tranparent rate (color alpha) for nodes in a level.
+	ColorAlpha []float32 `json:"colorAlpha,omitempty"`
+
+	// ColorSaturation indicates the range of saturation (color alpha) for nodes in a level.
+	ColorSaturation []float32 `json:"colorSaturation,omitempty"`
+
+	// ColorMappingBy specifies the rule according to which each node obtain color from color list.
+	ColorMappingBy string `json:"colorMappingBy,omitempty"`
+
+	// UpperLabel is used to specify whether show label when the treemap node has children.
+	UpperLabel *UpperLabel `json:"upperLabel,omitempty"`
+
+	// ItemStyle settings in this series data.
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
+
+	// Emphasis settings in this series data.
+	Emphasis *Emphasis `json:"emphasis,omitempty"`
+}
+
+// UpperLabel is used to specify whether show label when the treemap node has children.
+// https://echarts.apache.org/en/option.html#series-treemap.upperLabel
+type UpperLabel struct {
+	// Show is true to show upper label.
+	Show bool `json:"show,omitempty"`
+
+	// Position is the label's position.
+	// * top
+	// * left
+	// * right
+	// * bottom
+	// * inside
+	// * insideLeft
+	// * insideRight
+	// * insideTop
+	// * insideBottom
+	// * insideTopLeft
+	// * insideBottomLeft
+	// * insideTopRight
+	// * insideBottomRight
+	Position string `json:"position,omitempty"`
+
+	// Distance to the host graphic element.
+	// It is valid only when position is string value (like 'top', 'insideRight').
+	Distance float32 `json:"distance,omitempty"`
+
+	// Rotate label, from -90 degree to 90, positive value represents rotate anti-clockwise.
+	Rotate float32 `json:"rotate,omitempty"`
+
+	// Whether to move text slightly. For example: [30, 40] means move 30 horizontally and move 40 vertically.
+	Offset []float32 `json:"offset,omitempty"`
+
+	// Color is the text color
+	Color string `json:"color,omitempty"`
+
+	// FontStyle
+	// * "normal"
+	// * "italic"
+	// * "oblique"
+	FontStyle string `json:"fontStyle,omitempty"`
+
+	// FontWeight can be the string or a number
+	// * "normal"
+	// * "bold"
+	// * "bolder"
+	// * "lighter"
+	// 100 | 200 | 300| 400 ...
+	FontWeight interface{} `json:"fontWeight,omitempty"`
+
+	// FontSize
+	FontSize float32 `json:"fontSize,omitempty"`
+
+	// Align is a horizontal alignment of text, automatic by default.
+	// * "left"
+	// * "center"
+	// * "right"
+	Align string `json:"align,omitempty"`
+
+	// Align is a horizontal alignment of text, automatic by default.
+	// * "top"
+	// * "middle"
+	// * "bottom"
+	VerticalAlign string `json:"verticalAlign,omitempty"`
+
+	// Padding of the text fragment, for example:
+	// Padding: [3, 4, 5, 6]: represents padding of [top, right, bottom, left].
+	// Padding: 4: represents padding: [4, 4, 4, 4].
+	// Padding: [3, 4]: represents padding: [3, 4, 3, 4].
+	Padding interface{} `json:"padding,omitempty"`
+
+	// Width of text block
+	Width float32 `json:"width,omitempty"`
+
+	// Height of text block
+	Height float32 `json:"height,omitempty"`
+
+	// Upper label formatter, which supports string template and callback function.
+	// In either form, \n is supported to represent a new line.
+	// String template, Model variation includes:
+	//
+	// {a}: series name.
+	// {b}: the name of a data item.
+	// {c}: the value of a data item.
+	// {@xxx}: the value of a dimension named"xxx", for example,{@product}refers the value of"product"` dimension.
+	// {@[n]}: the value of a dimension at the index ofn, for example,{@[3]}` refers the value at dimensions[3].
+	Formatter string `json:"formatter,omitempty"`
 }
 
 // RGBColor returns the color with RGB format

--- a/types/charts.go
+++ b/types/charts.go
@@ -27,5 +27,6 @@ const (
 	ChartThemeRiver    = "themeRiver"
 	ChartWordCloud     = "wordCloud"
 	ChartTree          = "tree"
+	ChartTreeMap       = "treemap"
 	ChartSunburst      = "sunburst"
 )


### PR DESCRIPTION
This patch adds support in go-echarts for treemap type graph (already
supported in Apache ECharts).
https://echarts.apache.org/en/option.html#series-treemap

Closes #29