### PR TITLE
add label to `opts.GraphLink`

### DIFF
--- a/opts/charts.go
+++ b/opts/charts.go
@@ -249,6 +249,9 @@ type GraphLink struct {
 
 	// value of edge, can be mapped to edge length in force graph.
 	Value float32 `json:"value,omitempty"`
+
+	// Label for this link.
+	Label *EdgeLabel `json:"label,omitempty"`
 }
 
 // GraphCategory represents a category for data nodes.


### PR DESCRIPTION
Adds a binding to the JS [option](https://echarts.apache.org/en/option.html#series-graph.links.label).

This allows to label specific edges.