### PR TITLE
Change Step from bool to interface{} to allow string options

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -33,10 +33,10 @@ type SingleSeries struct {
 	FocusNodeAdjacency bool        `json:"focusNodeAdjacency,omitempty"`
 
 	// Line
-	Step         bool `json:"step,omitempty"`
-	Smooth       bool `json:"smooth,omitempty"`
-	ConnectNulls bool `json:"connectNulls,omitempty"`
-	ShowSymbol   bool `json:"showSymbol"`
+	Step         interface{} `json:"step,omitempty"`
+	Smooth       bool        `json:"smooth,omitempty"`
+	ConnectNulls bool        `json:"connectNulls,omitempty"`
+	ShowSymbol   bool        `json:"showSymbol"`
 
 	// Liquid
 	IsLiquidOutline bool `json:"outline,omitempty"`

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -311,7 +311,7 @@ type LineChart struct {
 
 	// Whether to show as a step line. It can be true, false. Or 'start', 'middle', 'end'.
 	// Which will configure the turn point of step line.
-	Step bool
+	Step interface{}
 
 	// Index of x axis to combine with, which is useful for multiple x axes in one chart.
 	XAxisIndex int


### PR DESCRIPTION
With this change it is possible to set Step to all possible options, according to https://echarts.apache.org/en/option.html#series-line.step:
true, false, "start", "middle", "end"