### PR TITLE
add axisPointers.Link opt

### DIFF
--- a/charts/bar.go
+++ b/charts/bar.go
@@ -41,7 +41,7 @@ func (c *Bar) SetXAxis(x interface{}) *Bar {
 // AddSeries adds the new series.
 func (c *Bar) AddSeries(name string, data []opts.BarData, options ...SeriesOpts) *Bar {
 	series := SingleSeries{Name: name, Type: types.ChartBar, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/base.go
+++ b/charts/base.go
@@ -19,15 +19,16 @@ type GlobalActions func(ba *BaseActions)
 
 // BaseConfiguration represents an option set needed by all chart types.
 type BaseConfiguration struct {
-	opts.Legend     `json:"legend"`
-	opts.Tooltip    `json:"tooltip"`
-	opts.Toolbox    `json:"toolbox"`
-	opts.Title      `json:"title"`
-	opts.Dataset    `json:"dataset"`
-	opts.Polar      `json:"polar"`
-	opts.AngleAxis  `json:"angleAxis"`
-	opts.RadiusAxis `json:"radiusAxis"`
-	opts.Brush      `json:"brush"`
+	opts.Legend       `json:"legend"`
+	opts.Tooltip      `json:"tooltip"`
+	opts.Toolbox      `json:"toolbox"`
+	opts.Title        `json:"title"`
+	opts.Dataset      `json:"dataset"`
+	opts.Polar        `json:"polar"`
+	opts.AngleAxis    `json:"angleAxis"`
+	opts.RadiusAxis   `json:"radiusAxis"`
+	opts.Brush        `json:"brush"`
+	*opts.AxisPointer `json:"axisPointer"`
 
 	render.Renderer        `json:"-"`
 	opts.Initialization    `json:"-"`
@@ -116,7 +117,9 @@ func (bc *BaseConfiguration) json() map[string]interface{} {
 		"series":  bc.MultiSeries,
 		"dataset": bc.Dataset,
 	}
-
+	if bc.AxisPointer != nil {
+		obj["axisPointer"] = bc.AxisPointer
+	}
 	if bc.hasPolar {
 		obj["polar"] = bc.Polar
 		obj["angleAxis"] = bc.AngleAxis
@@ -385,5 +388,12 @@ func reverseSlice(s []string) []string {
 func WithGridOpts(opt ...opts.Grid) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.GridList = append(bc.GridList, opt...)
+	}
+}
+
+// WithAxisPointerOpts sets the axis pointer.
+func WithAxisPointerOpts(opt *opts.AxisPointer) GlobalOpts {
+	return func(bc *BaseConfiguration) {
+		bc.AxisPointer = opt
 	}
 }

--- a/charts/boxplot.go
+++ b/charts/boxplot.go
@@ -32,7 +32,7 @@ func (c *BoxPlot) SetXAxis(x interface{}) *BoxPlot {
 // AddSeries adds the new series.
 func (c *BoxPlot) AddSeries(name string, data []opts.BoxPlotData, options ...SeriesOpts) *BoxPlot {
 	series := SingleSeries{Name: name, Type: types.ChartBoxPlot, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/chart3d.go
+++ b/charts/chart3d.go
@@ -50,7 +50,7 @@ func (c *Chart3D) addSeries(chartType, name string, data []opts.Chart3DData, opt
 		Data:        data,
 		CoordSystem: types.ChartCartesian3D,
 	}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 }
 

--- a/charts/effectscatter.go
+++ b/charts/effectscatter.go
@@ -32,7 +32,7 @@ func (c *EffectScatter) SetXAxis(x interface{}) *EffectScatter {
 // AddSeries adds the Y axis.
 func (c *EffectScatter) AddSeries(name string, data []opts.EffectScatterData, options ...SeriesOpts) *EffectScatter {
 	series := SingleSeries{Name: name, Type: types.ChartEffectScatter, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/funnel.go
+++ b/charts/funnel.go
@@ -26,7 +26,7 @@ func NewFunnel() *Funnel {
 // AddSeries adds new data sets.
 func (c *Funnel) AddSeries(name string, data []opts.FunnelData, options ...SeriesOpts) *Funnel {
 	series := SingleSeries{Name: name, Type: types.ChartFunnel, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/gauge.go
+++ b/charts/gauge.go
@@ -26,7 +26,7 @@ func NewGauge() *Gauge {
 // AddSeries adds new data sets.
 func (c *Gauge) AddSeries(name string, data []opts.GaugeData, options ...SeriesOpts) *Gauge {
 	series := SingleSeries{Name: name, Type: types.ChartGauge, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/geo.go
+++ b/charts/geo.go
@@ -38,7 +38,7 @@ func NewGeo() *Geo {
 // * types.ChartHeatMap
 func (c *Geo) AddSeries(name, geoType string, data []opts.GeoData, options ...SeriesOpts) *Geo {
 	series := SingleSeries{Name: name, Type: geoType, Data: data, CoordSystem: types.ChartGeo}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/graph.go
+++ b/charts/graph.go
@@ -26,7 +26,7 @@ func NewGraph() *Graph {
 // AddSeries adds the new series.
 func (c *Graph) AddSeries(name string, nodes []opts.GraphNode, links []opts.GraphLink, options ...SeriesOpts) *Graph {
 	series := SingleSeries{Name: name, Type: types.ChartGraph, Links: links, Data: nodes}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/heatmap.go
+++ b/charts/heatmap.go
@@ -32,7 +32,7 @@ func (c *HeatMap) SetXAxis(x interface{}) *HeatMap {
 // AddSeries adds the new series.
 func (c *HeatMap) AddSeries(name string, data []opts.HeatMapData, options ...SeriesOpts) *HeatMap {
 	series := SingleSeries{Name: name, Type: types.ChartHeatMap, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/kline.go
+++ b/charts/kline.go
@@ -32,7 +32,7 @@ func (c *Kline) SetXAxis(xAxis interface{}) *Kline {
 // AddSeries adds the new series.
 func (c *Kline) AddSeries(name string, data []opts.KlineData, options ...SeriesOpts) *Kline {
 	series := SingleSeries{Name: name, Type: types.ChartKline, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/line.go
+++ b/charts/line.go
@@ -32,7 +32,7 @@ func (c *Line) SetXAxis(x interface{}) *Line {
 // AddSeries adds the new series.
 func (c *Line) AddSeries(name string, data []opts.LineData, options ...SeriesOpts) *Line {
 	series := SingleSeries{Name: name, Type: types.ChartLine, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/liquid.go
+++ b/charts/liquid.go
@@ -27,7 +27,7 @@ func NewLiquid() *Liquid {
 // AddSeries adds new data sets.
 func (c *Liquid) AddSeries(name string, data []opts.LiquidData, options ...SeriesOpts) *Liquid {
 	series := SingleSeries{Name: name, Type: types.ChartLiquid, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/map.go
+++ b/charts/map.go
@@ -35,7 +35,7 @@ func (c *Map) RegisterMapType(mapType string) {
 // AddSeries adds new data sets.
 func (c *Map) AddSeries(name string, data []opts.MapData, options ...SeriesOpts) *Map {
 	series := SingleSeries{Name: name, Type: types.ChartMap, MapType: c.mapType, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/parallel.go
+++ b/charts/parallel.go
@@ -27,7 +27,7 @@ func NewParallel() *Parallel {
 // AddSeries adds new data sets.
 func (c *Parallel) AddSeries(name string, data []opts.ParallelData, options ...SeriesOpts) *Parallel {
 	series := SingleSeries{Name: name, Type: types.ChartParallel, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/pie.go
+++ b/charts/pie.go
@@ -26,7 +26,7 @@ func NewPie() *Pie {
 // AddSeries adds new data sets.
 func (c *Pie) AddSeries(name string, data []opts.PieData, options ...SeriesOpts) *Pie {
 	series := SingleSeries{Name: name, Type: types.ChartPie, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/radar.go
+++ b/charts/radar.go
@@ -27,7 +27,7 @@ func NewRadar() *Radar {
 // AddSeries adds new data sets.
 func (c *Radar) AddSeries(name string, data []opts.RadarData, options ...SeriesOpts) *Radar {
 	series := SingleSeries{Name: name, Type: types.ChartRadar, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	c.legends = append(c.legends, name)
 	return c

--- a/charts/sankey.go
+++ b/charts/sankey.go
@@ -26,7 +26,7 @@ func NewSankey() *Sankey {
 // AddSeries adds new data sets.
 func (c *Sankey) AddSeries(name string, nodes []opts.SankeyNode, links []opts.SankeyLink, options ...SeriesOpts) *Sankey {
 	series := SingleSeries{Name: name, Type: types.ChartSankey, Data: nodes, Links: links}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/scatter.go
+++ b/charts/scatter.go
@@ -32,7 +32,7 @@ func (c *Scatter) SetXAxis(x interface{}) *Scatter {
 // AddSeries adds the new series.
 func (c *Scatter) AddSeries(name string, data []opts.ScatterData, options ...SeriesOpts) *Scatter {
 	series := SingleSeries{Name: name, Type: types.ChartScatter, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/series.go
+++ b/charts/series.go
@@ -399,7 +399,7 @@ func WithMarkPointNameCoordItemOpts(opt ...opts.MarkPointNameCoordItem) SeriesOp
 	}
 }
 
-func (s *SingleSeries) configureSeriesOpts(options ...SeriesOpts) {
+func (s *SingleSeries) ConfigureSeriesOpts(options ...SeriesOpts) {
 	for _, opt := range options {
 		opt(s)
 	}
@@ -416,7 +416,7 @@ type MultiSeries []SingleSeries
 func (ms *MultiSeries) SetSeriesOptions(opts ...SeriesOpts) {
 	s := *ms
 	for i := 0; i < len(s); i++ {
-		s[i].configureSeriesOpts(opts...)
+		s[i].ConfigureSeriesOpts(opts...)
 	}
 }
 

--- a/charts/sunburst.go
+++ b/charts/sunburst.go
@@ -26,7 +26,7 @@ func NewSunburst() *Sunburst {
 // AddSeries adds new data sets.
 func (c *Sunburst) AddSeries(name string, data []opts.SunBurstData, options ...SeriesOpts) *Sunburst {
 	series := SingleSeries{Name: name, Type: types.ChartSunburst, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/themeriver.go
+++ b/charts/themeriver.go
@@ -31,7 +31,7 @@ func (c *ThemeRiver) AddSeries(name string, data []opts.ThemeRiverData, options 
 		cd[i] = data[i].ToList()
 	}
 	series := SingleSeries{Name: name, Type: types.ChartThemeRiver, Data: cd}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/tree.go
+++ b/charts/tree.go
@@ -26,7 +26,7 @@ func NewTree() *Tree {
 // AddSeries adds new data sets.
 func (c *Tree) AddSeries(name string, data []opts.TreeData, options ...SeriesOpts) *Tree {
 	series := SingleSeries{Name: name, Type: types.ChartTree, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/treemap.go
+++ b/charts/treemap.go
@@ -26,7 +26,7 @@ func NewTreeMap() *TreeMap {
 // AddSeries adds new data sets.
 func (c *TreeMap) AddSeries(name string, data []opts.TreeMapNode, options ...SeriesOpts) *TreeMap {
 	series := SingleSeries{Name: name, Type: types.ChartTreeMap, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	return c
 }

--- a/charts/wordcloud.go
+++ b/charts/wordcloud.go
@@ -34,7 +34,7 @@ func NewWordCloud() *WordCloud {
 // AddSeries adds new data sets.
 func (c *WordCloud) AddSeries(name string, data []opts.WordCloudData, options ...SeriesOpts) *WordCloud {
 	series := SingleSeries{Name: name, Type: types.ChartWordCloud, Data: data}
-	series.configureSeriesOpts(options...)
+	series.ConfigureSeriesOpts(options...)
 
 	// set default random color for WordCloud chart
 	if series.TextStyle == nil {

--- a/opts/global.go
+++ b/opts/global.go
@@ -357,6 +357,17 @@ type AxisPointer struct {
 	// 	Whether snap to point automatically. The default value is auto determined.
 	// This feature usually makes sense in value axis and time axis, where tiny points can be seeked automatically.
 	Snap bool `json:"snap,omitempty"`
+
+	Link []AxisPointerLink `json:"link,omitempty"`
+
+	Axis string `json:"axis,omitempty"`
+}
+
+type AxisPointerLink struct {
+	XAxisIndex []int  `json:"xAxisIndex,omitempty"`
+	YAxisIndex []int  `json:"yAxisIndex,omitempty"`
+	XAxisName  string `json:"xAxisName,omitempty"`
+	YAxisName  string `json:"yAxisName,omitempty"`
 }
 
 //Brush is an area-selecting component, with which user can select part of data from a chart to display in detail, or do calculations with them.
@@ -1395,6 +1406,11 @@ type Grid struct {
 
 	// Distance between grid component and the bottom side of the container.
 	Bottom string `json:"bottom,omitempty"`
+
+	// Width of grid component.
+	Width string `json:"width,omitempty"`
+
+	ContainLabel bool `json:"containLabel,omitempty"`
 
 	// Height of grid component. Adaptive by default.
 	Height string `json:"height,omitempty"`


### PR DESCRIPTION
axisPointers can be linked to each other. The term "link" represents that axes are synchronized and move together. Axes are linked according to the value of axisPointer.

the `series.configureSeriesOpts` method should pub for easy configuration of series individually.
like 
``` go
func AddMarkPoint(kline *charts.Kline, seriesIndex int, text string, Color string, x interface{}, y interface{}) {
	if len(kline.MultiSeries) > seriesIndex {
		kline.MultiSeries[seriesIndex].ConfigureSeriesOpts(
			charts.WithMarkPointNameCoordItemOpts(opts.MarkPointNameCoordItem{
				Name:       text,
				Coordinate: []interface{}{x, y},
				Label: &opts.Label{
					Show:      true,
					Formatter: text,
				},
				ItemStyle: &opts.ItemStyle{
					Color: Color,
					Opacity: 0.8,
				},
			}),
		)
	}

}

```


refer:
https://echarts.apache.org/examples/en/view.html?c=candlestick-brush&edit=1&reset=1