### PR TITLE
added mark area to charts series and opts series

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -98,6 +98,7 @@ type SingleSeries struct {
 	*opts.LabelLine     `json:"labelLine,omitempty"`
 	*opts.Emphasis      `json:"emphasis,omitempty"`
 	*opts.MarkLines     `json:"markLine,omitempty"`
+	*opts.MarkAreas     `json:"markArea,omitempty"`
 	*opts.MarkPoints    `json:"markPoint,omitempty"`
 	*opts.RippleEffect  `json:"rippleEffect,omitempty"`
 	*opts.LineStyle     `json:"lineStyle,omitempty"`
@@ -364,6 +365,69 @@ func WithMarkLineNameYAxisItemOpts(opt ...opts.MarkLineNameYAxisItem) SeriesOpts
 	}
 }
 
+// WithMarkAreaNameTypeItemOpts sets the type of the MarkArea.
+func WithMarkAreaNameTypeItemOpts(opt ...opts.MarkAreaNameTypeItem) SeriesOpts {
+	return func(s *SingleSeries) {
+		if s.MarkAreas == nil {
+			s.MarkAreas = &opts.MarkAreas{}
+		}
+		for _, o := range opt {
+			s.MarkAreas.Data = append(s.MarkAreas.Data, o)
+		}
+	}
+}
+
+// WithMarkAreaStyleOpts sets the style of the MarkArea.
+func WithMarkAreaStyleOpts(opt opts.MarkAreaStyle) SeriesOpts {
+	return func(s *SingleSeries) {
+		if s.MarkAreas == nil {
+			s.MarkAreas = &opts.MarkAreas{}
+		}
+
+		s.MarkAreas.MarkAreaStyle = opt
+	}
+}
+
+// WithMarkAreaNameCoordItemOpts sets the coordinates of the MarkLine.
+func WithMarkAreaNameCoordItemOpts(opt ...opts.MarkAreaNameCoordItem) SeriesOpts {
+	type MANameCoord struct {
+		Name  string        `json:"name,omitempty"`
+		Coord []interface{} `json:"coord"`
+	}
+	return func(s *SingleSeries) {
+		if s.MarkAreas == nil {
+			s.MarkAreas = &opts.MarkAreas{}
+		}
+		for _, o := range opt {
+			s.MarkLines.Data = append(s.MarkLines.Data, []MANameCoord{{Name: o.Name, Coord: o.Coordinate0}, {Coord: o.Coordinate1}})
+		}
+	}
+}
+
+// WithMarkAreaNameXAxisItemOpts sets the X axis of the MarkLine.
+func WithMarkAreaNameXAxisItemOpts(opt ...opts.MarkAreaNameXAxisItem) SeriesOpts {
+	return func(s *SingleSeries) {
+		if s.MarkAreas == nil {
+			s.MarkAreas = &opts.MarkAreas{}
+		}
+		for _, o := range opt {
+			s.MarkAreas.Data = append(s.MarkAreas.Data, o)
+		}
+	}
+}
+
+// WithMarkAreaNameYAxisItemOpts sets the Y axis of the MarkLine.
+func WithMarkAreaNameYAxisItemOpts(opt ...opts.MarkAreaNameYAxisItem) SeriesOpts {
+	return func(s *SingleSeries) {
+		if s.MarkAreas == nil {
+			s.MarkAreas = &opts.MarkAreas{}
+		}
+		for _, o := range opt {
+			s.MarkAreas.Data = append(s.MarkAreas.Data, o)
+		}
+	}
+}
+
 // WithMarkPointNameTypeItemOpts sets the type of the MarkPoint.
 func WithMarkPointNameTypeItemOpts(opt ...opts.MarkPointNameTypeItem) SeriesOpts {
 	return func(s *SingleSeries) {
@@ -411,7 +475,9 @@ type MultiSeries []SingleSeries
 // SetSeriesOptions sets options for all the series.
 // Previous options will be overwrote every time hence setting them on the `AddSeries` if you want
 // to customize each series individually
-// 															 here -> ↓ <-
+//
+//	here -> ↓ <-
+//
 // func (c *Bar) AddSeries(name string, data []opts.BarData, options ...SeriesOpts)
 func (ms *MultiSeries) SetSeriesOptions(opts ...SeriesOpts) {
 	s := *ms

--- a/charts/series.go
+++ b/charts/series.go
@@ -399,7 +399,7 @@ func WithMarkAreaNameCoordItemOpts(opt ...opts.MarkAreaNameCoordItem) SeriesOpts
 			s.MarkAreas = &opts.MarkAreas{}
 		}
 		for _, o := range opt {
-			s.MarkLines.Data = append(s.MarkLines.Data, []MANameCoord{{Name: o.Name, Coord: o.Coordinate0}, {Coord: o.Coordinate1}})
+			s.MarkAreas.Data = append(s.MarkAreas.Data, []MANameCoord{{Name: o.Name, Coord: o.Coordinate0}, {Coord: o.Coordinate1}})
 		}
 	}
 }

--- a/charts/series.go
+++ b/charts/series.go
@@ -391,15 +391,16 @@ func WithMarkAreaStyleOpts(opt opts.MarkAreaStyle) SeriesOpts {
 // WithMarkAreaNameCoordItemOpts sets the coordinates of the MarkLine.
 func WithMarkAreaNameCoordItemOpts(opt ...opts.MarkAreaNameCoordItem) SeriesOpts {
 	type MANameCoord struct {
-		Name  string        `json:"name,omitempty"`
-		Coord []interface{} `json:"coord"`
+		Name      string          `json:"name,omitempty"`
+		ItemStyle *opts.ItemStyle `json:"itemStyle"`
+		Coord     []interface{}   `json:"coord"`
 	}
 	return func(s *SingleSeries) {
 		if s.MarkAreas == nil {
 			s.MarkAreas = &opts.MarkAreas{}
 		}
 		for _, o := range opt {
-			s.MarkAreas.Data = append(s.MarkAreas.Data, []MANameCoord{{Name: o.Name, Coord: o.Coordinate0}, {Coord: o.Coordinate1}})
+			s.MarkAreas.Data = append(s.MarkAreas.Data, []MANameCoord{{Name: o.Name, ItemStyle: o.ItemStyle, Coord: o.Coordinate0}, {Coord: o.Coordinate1}})
 		}
 	}
 }

--- a/opts/series.go
+++ b/opts/series.go
@@ -41,7 +41,7 @@ type Label struct {
 	LineHeight float32 `json:"lineHeight,omitempty"`
 
 	// Background color of the text fragment.
-	BackgroundColor  string `json:"backgroundColor,omitempty"`
+	BackgroundColor string `json:"backgroundColor,omitempty"`
 
 	// Border color of the text fragment.
 	BorderColor string `json:"borderColor,omitempty"`
@@ -234,6 +234,72 @@ type MarkLineNameCoordItem struct {
 	Coordinate0 []interface{}
 
 	// Mark line end coordinate
+	Coordinate1 []interface{}
+
+	// Works only when type is assigned.
+	// It is used to state the dimension used to calculate maximum value or minimum value.
+	// It may be the direct name of a dimension, like x,
+	// or angle for line charts, or open, or close for candlestick charts.
+	ValueDim string `json:"valueDim,omitempty"`
+}
+
+// MarkAreas represents a series of markareas.
+type MarkAreas struct {
+	Data []interface{} `json:"data,omitempty"`
+	MarkAreaStyle
+}
+
+// MarkAreaStyle contains styling options for a MarkArea.
+type MarkAreaStyle struct {
+	// Mark area text options.
+	Label *Label `json:"label,omitempty"`
+
+	// ItemStyle settings
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
+}
+
+// MarkAreaNameTypeItem represents type for a MarkArea.
+type MarkAreaNameTypeItem struct {
+	// Mark area name.
+	Name string `json:"name,omitempty"`
+
+	// Mark area type, options: "average", "min", "max".
+	Type string `json:"type,omitempty"`
+
+	// Works only when type is assigned.
+	// It is used to state the dimension used to calculate maximum value or minimum value.
+	// It may be the direct name of a dimension, like x,
+	// or angle for line charts, or open, or close for candlestick charts.
+	ValueDim string `json:"valueDim,omitempty"`
+}
+
+// MarkAreaNameYAxisItem defines a MarkArea on a Y axis.
+type MarkAreaNameYAxisItem struct {
+	// Mark area name
+	Name string `json:"name,omitempty"`
+
+	// Y axis data
+	YAxis interface{} `json:"yAxis,omitempty"`
+}
+
+// MarkAreaNameXAxisItem defines a MarkArea on a X axis.
+type MarkAreaNameXAxisItem struct {
+	// Mark area name
+	Name string `json:"name,omitempty"`
+
+	// X axis data
+	XAxis interface{} `json:"xAxis,omitempty"`
+}
+
+// MarkAreaNameCoordItem represents coordinates for a MarkArea.
+type MarkAreaNameCoordItem struct {
+	// Mark area name
+	Name string `json:"name,omitempty"`
+
+	// Mark area start coordinate
+	Coordinate0 []interface{}
+
+	// Mark area end coordinate
 	Coordinate1 []interface{}
 
 	// Works only when type is assigned.
@@ -606,8 +672,8 @@ type EdgeLabel struct {
 	Formatter string `json:"formatter,omitempty"`
 }
 
-//Define what is encoded to for each dimension of data
-//https://echarts.apache.org/en/option.html#series-candlestick.encode
+// Define what is encoded to for each dimension of data
+// https://echarts.apache.org/en/option.html#series-candlestick.encode
 type Encode struct {
 	X interface{} `json:"x"`
 

--- a/opts/series.go
+++ b/opts/series.go
@@ -271,6 +271,9 @@ type MarkAreaNameTypeItem struct {
 	// It may be the direct name of a dimension, like x,
 	// or angle for line charts, or open, or close for candlestick charts.
 	ValueDim string `json:"valueDim,omitempty"`
+
+	// ItemStyle settings
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 }
 
 // MarkAreaNameYAxisItem defines a MarkArea on a Y axis.
@@ -307,6 +310,9 @@ type MarkAreaNameCoordItem struct {
 	// It may be the direct name of a dimension, like x,
 	// or angle for line charts, or open, or close for candlestick charts.
 	ValueDim string `json:"valueDim,omitempty"`
+
+	// Mark point text options.
+	Label *Label `json:"label,omitempty"`
 
 	// ItemStyle settings
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`

--- a/opts/series.go
+++ b/opts/series.go
@@ -307,6 +307,9 @@ type MarkAreaNameCoordItem struct {
 	// It may be the direct name of a dimension, like x,
 	// or angle for line charts, or open, or close for candlestick charts.
 	ValueDim string `json:"valueDim,omitempty"`
+
+	// ItemStyle settings
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 }
 
 // MarkPoints represents a series of markpoints.


### PR DESCRIPTION
impl missing mark areas

```go
charts.WithMarkAreaNameCoordItemOpts(opts.MarkAreaNameCoordItem{
	Name:        "TEST",
	Coordinate0: []interface{}{"25.02.22 02:30", 1.120},
	Coordinate1: []interface{}{"25.02.22 10:30", 1.125},
	ItemStyle: &opts.ItemStyle{
		Color: "rgba(55, 173, 177, 0.4)",
	},
}),
```
![image](https://user-images.githubusercontent.com/6347840/206516793-1553c1c4-69ea-45cb-acc7-5ea99e4a0f24.png)
