### PR TITLE
Do not omit empty flags (false gets omitted), correctly assign ShowSymbol

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -34,8 +34,8 @@ type SingleSeries struct {
 
 	// Line
 	Step         interface{} `json:"step,omitempty"`
-	Smooth       bool        `json:"smooth,omitempty"`
-	ConnectNulls bool        `json:"connectNulls,omitempty"`
+	Smooth       bool        `json:"smooth"`
+	ConnectNulls bool        `json:"connectNulls"`
 	ShowSymbol   bool        `json:"showSymbol"`
 
 	// Liquid
@@ -221,6 +221,7 @@ func WithLineChartOpts(opt opts.LineChart) SeriesOpts {
 		s.YAxisIndex = opt.YAxisIndex
 		s.Stack = opt.Stack
 		s.Smooth = opt.Smooth
+		s.ShowSymbol = opt.ShowSymbol
 		s.Step = opt.Step
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex


### PR DESCRIPTION
This PR fixes issues with the `Smooth` and `ConnectNulls` flag. They had `omitempty` which omitted them when they were `false` and therefore were ignored when set to `false`.
Also the `ShowSymbol` was not assigned and therefore ignored.