### PR TITLE
Add dimension to opt.VisualMap

### DIFF
--- a/opts/global.go
+++ b/opts/global.go
@@ -858,6 +858,9 @@ type VisualMap struct {
 	// The label text on both ends, such as ['High', 'Low'].
 	Text []string `json:"text,omitempty"`
 
+	// Specify which dimension should be used to fetch dataValue from series.data, and then map them to visual channel.
+	Dimension string `json:"dimension,omitempty"`
+
 	// Define visual channels that will mapped from dataValues that are in selected range.
 	InRange *VisualMapInRange `json:"inRange,omitempty"`
 


### PR DESCRIPTION
I need to apply a visual map along the x axis and as far as I understand, the dimension attribute can be used to specify that which was missing from the structure.