### PR TITLE
Fix build.sh help text

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ function release() {
 }
 
 function help() {
-    echo "$0 --cmd [format|test|release]"
+    echo "$0 [format|test|release]"
 }
 
 if [ "$1" == "" ]; then


### PR DESCRIPTION
Since arguments are checked with `$1`, adding `--cmd` like suggested in the help text would require the use of `$2`.