### PR TITLE
Add pieces to opt.VisualMap

### DIFF
--- a/opts/global.go
+++ b/opts/global.go
@@ -834,6 +834,24 @@ type SplitLine struct {
 	AlignWithLabel bool `json:"alignWithLabel,omitempty"`
 }
 
+// Used to customize how to slice continuous data, and some specific view style for some pieces.
+type Piece struct {
+	Min float32 `json:"min,omitempty"`
+
+	Max float32 `json:"max,omitempty"`
+
+	Lt float32 `json:"lt,omitempty"`
+
+	Lte float32 `json:"lte,omitempty"`
+
+	Gt float32 `json:"gt,omitempty"`
+
+	Gte float32 `json:"gte,omitempty"`
+
+	// Symbol color
+	Color string `json:"color,omitempty"`
+}
+
 // VisualMap is a type of component for visual encoding, which maps the data to visual channels.
 // https://echarts.apache.org/en/option.html#visualMap
 type VisualMap struct {
@@ -860,6 +878,9 @@ type VisualMap struct {
 
 	// Define visual channels that will mapped from dataValues that are in selected range.
 	InRange *VisualMapInRange `json:"inRange,omitempty"`
+
+	// Used to customize how to slice continuous data, and some specific view style for some pieces.
+	Pieces []Piece `json:"pieces,omitempty"`
 
 	// Whether to show visualMap-piecewise component. If set as false,
 	// visualMap-piecewise component will not show,


### PR DESCRIPTION
This is another attribute I require to reproduce the colored graph shown in this example: https://echarts.apache.org/examples/en/editor.html?c=line-sections

I wanted to document `Min`, `Max`, `Lt`, `Lte`, `Gt` and `Gte` but I can't find documentation from echart where those attributes are properly described. Those values are just used in some of their examples.