### PR TITLE
fix: default val override.

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -191,11 +191,17 @@ func (bc *BaseConfiguration) GetAssets() opts.Assets {
 	return bc.Assets
 }
 
+// FillDefaultValues fill default values for chart options.
+func (bc *BaseConfiguration) FillDefaultValues() {
+	opts.SetDefaultValue(bc)
+}
+
 func (bc *BaseConfiguration) initBaseConfiguration() {
 	bc.initSeriesColors()
 	bc.InitAssets()
 	bc.initXYAxis()
 	bc.Initialization.Validate()
+	bc.FillDefaultValues()
 }
 
 func (bc *BaseConfiguration) initSeriesColors() {

--- a/components/page.go
+++ b/components/page.go
@@ -17,6 +17,7 @@ const (
 type Charter interface {
 	Type() string
 	GetAssets() opts.Assets
+	FillDefaultValues()
 	Validate()
 }
 

--- a/opts/global.go
+++ b/opts/global.go
@@ -42,22 +42,30 @@ type Initialization struct {
 
 // Validate validates the initialization configurations.
 func (opt *Initialization) Validate() {
-	setDefaultValue(opt)
+	SetDefaultValue(opt)
 	if opt.ChartID == "" {
 		opt.ChartID = generateUniqueID()
 	}
 }
 
 // set default values for the struct field.
-// origin from: https://github.com/mcuadros/go-defaults
-func setDefaultValue(ptr interface{}) {
+// inspired from: https://github.com/mcuadros/go-defaults
+func SetDefaultValue(ptr interface{}) {
 	elem := reflect.ValueOf(ptr).Elem()
-	t := elem.Type()
+	walkField(elem)
+}
+
+func walkField(val reflect.Value) {
+	t := val.Type()
 
 	for i := 0; i < t.NumField(); i++ {
-		// handle `default` tag only
+		f := val.Field(i)
+		if f.Kind() == reflect.Struct {
+			walkField(f)
+		}
+
 		if defaultVal := t.Field(i).Tag.Get("default"); defaultVal != "" {
-			setField(elem.Field(i), defaultVal)
+			setField(val.Field(i), defaultVal)
 		}
 	}
 }
@@ -156,7 +164,8 @@ type Title struct {
 // https://echarts.apache.org/en/option.html#legend
 type Legend struct {
 	// Whether to show the Legend, default true.
-	Show bool `json:"show"`
+	// Once you set other options, need to manually set it to true
+	Show bool `json:"show" default:"true"`
 
 	// Type of legend. Optional values:
 	// "plain": Simple legend. (default)


### PR DESCRIPTION
// TODO
For now it gonna set the init default options, but can be replaces by custom options.
Maybe we should do the `merge` opt instead of `replace` or find a way to set default val before render .
close #271 