### PR TITLE
NM Various Enhancements

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -23,7 +23,6 @@ type BaseConfiguration struct {
 	opts.Tooltip      `json:"tooltip"`
 	opts.Toolbox      `json:"toolbox"`
 	opts.Title        `json:"title"`
-	opts.Dataset      `json:"dataset"`
 	opts.Polar        `json:"polar"`
 	opts.AngleAxis    `json:"angleAxis"`
 	opts.RadiusAxis   `json:"radiusAxis"`
@@ -57,6 +56,9 @@ type BaseConfiguration struct {
 
 	// Animation whether enable the animation, default true
 	Animation bool `json:"animation" default:"true"`
+
+	// Array of datasets, managed by AddDataset()
+	DatasetList []opts.Dataset `json:"dataset,omitempty"`
 
 	DataZoomList  []opts.DataZoom  `json:"datazoom,omitempty"`
 	VisualMapList []opts.VisualMap `json:"visualmap,omitempty"`
@@ -119,9 +121,14 @@ func (bc *BaseConfiguration) json() map[string]interface{} {
 		"animation": bc.Animation,
 		"tooltip":   bc.Tooltip,
 		"series":    bc.MultiSeries,
-		"dataset":   bc.Dataset,
 	}
+	// if only one item, use it directly instead of an Array
+	if len(bc.DatasetList) == 1 {
+		obj["dataset"] = bc.DatasetList[0]
+	} else if len(bc.DatasetList) > 1 {
+		obj["dataset"] = bc.DatasetList
 
+	}
 	if bc.AxisPointer != nil {
 		obj["axisPointer"] = bc.AxisPointer
 	}
@@ -195,6 +202,11 @@ func (bc *BaseConfiguration) json() map[string]interface{} {
 // GetAssets returns the Assets options.
 func (bc *BaseConfiguration) GetAssets() opts.Assets {
 	return bc.Assets
+}
+
+// AddDataset adds a Dataset to this chart
+func (bc *BaseConfiguration) AddDataset(dataset ...opts.Dataset) {
+	bc.DatasetList = append(bc.DatasetList, dataset...)
 }
 
 // FillDefaultValues fill default values for chart options.

--- a/charts/rectangle.go
+++ b/charts/rectangle.go
@@ -84,7 +84,7 @@ func (rc *RectChart) SetGlobalOptions(options ...GlobalOpts) *RectChart {
 	return rc
 }
 
-//SetDispatchActions sets actions for the RectChart instance.
+// SetDispatchActions sets actions for the RectChart instance.
 func (rc *RectChart) SetDispatchActions(options ...GlobalActions) *RectChart {
 	rc.RectConfiguration.setRectGlobalActions(options...)
 	return rc

--- a/charts/series.go
+++ b/charts/series.go
@@ -96,7 +96,8 @@ type SingleSeries struct {
 	AnimationDelayUpdate    int    `json:"animationDelayUpdate,omitempty"`
 
 	// series data
-	Data interface{} `json:"data"`
+	Data         interface{} `json:"data,omitempty"`
+	DatasetIndex int         `json:"datasetIndex,omitempty"`
 
 	// series options
 	*opts.Encode        `json:"encode,omitempty"`
@@ -532,5 +533,12 @@ func (ms *MultiSeries) SetSeriesOptions(opts ...SeriesOpts) {
 func WithEncodeOpts(opt opts.Encode) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Encode = &opt
+	}
+}
+
+// WithDatasetIndex sets the datasetIndex option.
+func WithDatasetIndex(index int) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.DatasetIndex = index
 	}
 }

--- a/opts/global.go
+++ b/opts/global.go
@@ -377,7 +377,7 @@ type AxisPointer struct {
 
 	Axis string `json:"axis,omitempty"`
 
-	Show bool `json:"show,omitempty"`
+	Show bool `json:"show"`
 
 	Label *Label `json:"label,omitempty"`
 }

--- a/opts/global.go
+++ b/opts/global.go
@@ -1211,8 +1211,8 @@ type RadiusAxis struct {
 	Inverse       bool      `json:"inverse,omitempty"`
 }
 
+var newlineTabPat = regexp.MustCompile(`\n|\t`)
 var commentPat = regexp.MustCompile(`(//.*)\n`)
-var funcPat = regexp.MustCompile(`\n|\t`)
 
 const funcMarker = "__f__"
 
@@ -1223,25 +1223,25 @@ type JSFunctions struct {
 // AddJSFuncs adds a new JS function.
 func (f *JSFunctions) AddJSFuncs(fn ...string) {
 	for i := 0; i < len(fn); i++ {
-		f.Fns = append(f.Fns, funcPat.ReplaceAllString(fn[i], ""))
+		f.Fns = append(f.Fns, newlineTabPat.ReplaceAllString(fn[i], ""))
 	}
 }
 
-// FuncOpts is the option set for handling function type.
+// FuncOpts returns a string suitable for options expecting JavaScript code.
 func FuncOpts(fn string) string {
-	fn = commentPat.ReplaceAllString(fn, "")
 	return replaceJsFuncs(fn)
 }
 
-// FuncStripCommentsOpts is the option set for handling function type,
-// stripping the '//' comments from the function string.
-func FuncNoStripOpts(fn string) string {
+// FuncStripCommentsOpts returns a string suitable for options expecting JavaScript code,
+// stripping '//' comments.
+func FuncStripCommentsOpts(fn string) string {
+	fn = commentPat.ReplaceAllString(fn, "")
 	return replaceJsFuncs(fn)
 }
 
 // replace and clear up js functions string
 func replaceJsFuncs(fn string) string {
-	fn = funcPat.ReplaceAllString(fn, "")
+	fn = newlineTabPat.ReplaceAllString(fn, "")
 	return fmt.Sprintf("%s%s%s", funcMarker, fn, funcMarker)
 }
 

--- a/opts/global.go
+++ b/opts/global.go
@@ -1183,6 +1183,7 @@ type RadiusAxis struct {
 	Inverse       bool      `json:"inverse,omitempty"`
 }
 
+var commentPat = regexp.MustCompile(`(//.*)\n`)
 var funcPat = regexp.MustCompile(`\n|\t`)
 
 const funcMarker = "__f__"
@@ -1200,11 +1201,19 @@ func (f *JSFunctions) AddJSFuncs(fn ...string) {
 
 // FuncOpts is the option set for handling function type.
 func FuncOpts(fn string) string {
+	fn = commentPat.ReplaceAllString(fn, "")
+	return replaceJsFuncs(fn)
+}
+
+// FuncStripCommentsOpts is the option set for handling function type,
+// stripping the '//' comments from the function string.
+func FuncNoStripOpts(fn string) string {
 	return replaceJsFuncs(fn)
 }
 
 // replace and clear up js functions string
 func replaceJsFuncs(fn string) string {
+	fn = funcPat.ReplaceAllString(fn, "")
 	return fmt.Sprintf("%s%s%s", funcMarker, funcPat.ReplaceAllString(fn, ""), funcMarker)
 }
 

--- a/opts/global.go
+++ b/opts/global.go
@@ -351,6 +351,8 @@ type Tooltip struct {
 	// }
 	Formatter string `json:"formatter,omitempty"`
 
+	ValueFormatter string `json:"valueFormatter,omitempty"`
+
 	// Configuration item for axisPointer
 	AxisPointer *AxisPointer `json:"axisPointer,omitempty"`
 }
@@ -374,6 +376,10 @@ type AxisPointer struct {
 	Link []AxisPointerLink `json:"link,omitempty"`
 
 	Axis string `json:"axis,omitempty"`
+
+	Show bool `json:"show,omitempty"`
+
+	Label *Label `json:"label,omitempty"`
 }
 
 type AxisPointerLink struct {
@@ -617,6 +623,8 @@ type AxisLabel struct {
 	VerticalAlign string `json:"verticalAlign,omitempty"`
 	// Line height of the axis label
 	LineHeight string `json:"lineHeight,omitempty"`
+
+	BackgroundColor string `json:"backgroundColor,omitempty"`
 }
 
 type AxisTick struct {
@@ -732,6 +740,9 @@ type XAxis struct {
 
 	// Settings related to axis tick.
 	AxisTick *AxisTick `json:"axisTick,omitempty"`
+
+	// Settings related to axis pointer.
+	AxisPointer *AxisPointer `json:"axisPointer,omitempty"`
 }
 
 // YAxis is the option set for Y axis.
@@ -795,6 +806,9 @@ type YAxis struct {
 
 	// Settings related to axis line.
 	AxisLine *AxisLine `json:"axisLine,omitempty"`
+
+	// Settings related to axis pointer.
+	AxisPointer *AxisPointer `json:"axisPointer,omitempty"`
 }
 
 // TextStyle is the option set for a text style component.
@@ -974,6 +988,20 @@ type DataZoom struct {
 	// If it is set as a single number, one axis is controlled, while if it is set as an Array ,
 	// multiple axes are controlled.
 	YAxisIndex interface{} `json:"yAxisIndex,omitempty"`
+
+	// LabelFormatter is the formatter tool for the label.
+	//
+	// If it is a string, it will be a template. For instance, aaaa{value}bbbb, where {value} will be replaced by the value of actual data value.
+	// It can also be a callback function. For example:
+	//
+	// /** @param {*} value If axis.type is 'category', `value` is the index of axis.data.
+	//  *                   else `value` is current value.
+	//  * @param {string} valueStr Inner formatted string.
+	//  * @return {string} Returns the label formatted.
+	//  labelFormatter: function (value, valueStr) {
+	//     return 'aaa' + value + 'bbb';
+	// }
+	LabelFormatter string `json:"labelFormatter,omitempty"`
 }
 
 // SingleAxis is the option set for single axis.
@@ -1214,7 +1242,7 @@ func FuncNoStripOpts(fn string) string {
 // replace and clear up js functions string
 func replaceJsFuncs(fn string) string {
 	fn = funcPat.ReplaceAllString(fn, "")
-	return fmt.Sprintf("%s%s%s", funcMarker, funcPat.ReplaceAllString(fn, ""), funcMarker)
+	return fmt.Sprintf("%s%s%s", funcMarker, fn, funcMarker)
 }
 
 type Colors []string


### PR DESCRIPTION
# Description

> Please share your ideas and awesome changes.  

I've been loving this library -- such a great integration of Golang <> JSON <> eCharts.    It took me a while to isolate my changes, but I finally rebased them for a PR.   Since one has a breaking change, maybe you want to separate it and I will if you ask me to.

Three changes, one adds some missing fields:

       * Tooltip.ValueFormatter
       * AxisPointer.Show
       * AxisPointer.Label
       * AxisLabel.BackgroundColor
       * XAxis.AxisPointer
       * YAxis.AxisPointer
       * DataZoom.LabelFormatter

Another strips `//` comments from JavaScript code, while still having `FuncNoStripOpts` if somehow that's not wanted.  But most JavaScript code will.   This makes using `go:embed` much easier (which I'll add a PR to `examples` about).

The last adds support for multiple datasets.  This is great for issues like It has #169 with multiple charts.  This has one breaking change, but in my opinion it adds so much power and harmonizes the syntax:
```
    // old
    chart.Dataset = opts.Dataset{Source: test}
    // new
    chart.AddDataset(opts.Dataset{Source: test})
```

---
# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [X] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others


---
# Examples:

- [X] Yes, I am willing to submit a PR on [Examples](https://github.com/go-echarts/examples)!

A multi-dataset example would be super useful.  I don't have much time but hope to get to it.

I also want to make an example using `go:embed` since it is so powerful (also needs `go 1.16` whereas examples only uses `go 1.15`).  But I won't have time for a while too.   Here's the idea:

```
// go:embed js/tooltip.js
var tooltipFormatter string
....
charts.WithTooltipOpts(opts.Tooltip{
	Show:    true,
	Trigger: "axis",
	Formatter: opts.FuncOpts(tooltipFormatter),
}
```
`js/tooltip.js`
```
function (params) {
    // here's a comment!
    console.log(params);
}
```