### PR TITLE
fix(render):musttemplate adds funcs to template before parsing

### DIFF
--- a/render/engine.go
+++ b/render/engine.go
@@ -23,9 +23,7 @@ const (
 	ModPage  = "page"
 )
 
-var (
-	pat = regexp.MustCompile(`(__f__")|("__f__)|(__f__)`)
-)
+var pat = regexp.MustCompile(`(__f__")|("__f__)|(__f__)`)
 
 type pageRender struct {
 	c      interface{}
@@ -105,12 +103,13 @@ func isSet(name string, data interface{}) bool {
 
 // MustTemplate creates a new template with the given name and parsed contents.
 func MustTemplate(name string, contents []string) *template.Template {
-	tpl := template.Must(template.New(name).Parse(contents[0])).Funcs(template.FuncMap{
+	tpl := template.New(name).Funcs(template.FuncMap{
 		"safeJS": func(s interface{}) template.JS {
 			return template.JS(fmt.Sprint(s))
 		},
 		"isSet": isSet,
 	})
+	tpl = template.Must(tpl.Parse(contents[0]))
 
 	for _, cont := range contents[1:] {
 		tpl = template.Must(tpl.Parse(cont))


### PR DESCRIPTION


# Description
Calls `.Funcs` before `.Parse` as is mentioned here: https://pkg.go.dev/text/template#Template.Funcs


Fixes #292 

---
# Type of change

- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others
