### PR TITLE
feat: encode properties for any series dataset added

### DIFF
--- a/opts/series.go
+++ b/opts/series.go
@@ -615,7 +615,6 @@ func HSLAColor(h, s, l, a float32) string {
 // EdgeLabel is the properties of an label of edge.
 // https://echarts.apache.org/en/option.html#series-graph.edgeLabel
 type EdgeLabel struct {
-
 	// Show is true to show label on edge.
 	Show bool `json:"show,omitempty"`
 
@@ -687,4 +686,14 @@ type Encode struct {
 	X interface{} `json:"x"`
 
 	Y interface{} `json:"y"`
+
+	Tooltip interface{} `json:"tooltip,omitempty"`
+
+	SeriesName interface{} `json:"seriesName,omitempty"`
+
+	ItemID interface{} `json:"itemId,omitempty"`
+
+	ItemName interface{} `json:"itemName,omitempty"`
+
+	ItemGroupID interface{} `json:"itemGroupId,omitempty"`
 }


### PR DESCRIPTION
# Description
> Please share your ideas and awesome changes.  

Some of the dataset encoding parameters for series are not included in the `opts/series` encoding options. This MR adds the missing options.

The echarts documentation that is already linked in the code here shows these options.

Fixes #302 

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others


---
# Examples:
Are you willing to submit a PR on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
charts examples to more users.

- [ ] Yes, I am willing to submit a PR on [Examples](https://github.com/go-echarts/examples)!

<!-- The related PRs in Example : -->

