### PR TITLE
feat: added tooltip property to graph node

### DIFF
--- a/opts/charts.go
+++ b/opts/charts.go
@@ -236,6 +236,9 @@ type GraphNode struct {
 
 	// The style of this node.
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
+
+	// The tooltip of this node.
+	Tooltip *Tooltip `json:"tooltip,omitempty"`
 }
 
 // GraphLink represents relationship between two data nodes.


### PR DESCRIPTION
# Description
Adds `Tooltip` field to `GraphNode` to allow configuration of tooltip on a per-node basis.

Fixes #304

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others


---
# Examples:
Are you willing to submit a PR on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
charts examples to more users.

- [ ] Yes, I am willing to submit a PR on [Examples](https://github.com/go-echarts/examples)!