### PR TITLE
feat: added symbolKeepAspect option to graph series

### DIFF
--- a/charts/radar.go
+++ b/charts/radar.go
@@ -10,6 +10,9 @@ import (
 type Radar struct {
 	BaseConfiguration
 	BaseActions
+
+	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
+	SymbolKeepAspect bool
 }
 
 // Type returns the chart type.
@@ -26,7 +29,7 @@ func NewRadar() *Radar {
 
 // AddSeries adds new data sets.
 func (c *Radar) AddSeries(name string, data []opts.RadarData, options ...SeriesOpts) *Radar {
-	series := SingleSeries{Name: name, Type: types.ChartRadar, Data: data}
+	series := SingleSeries{Name: name, Type: types.ChartRadar, Data: data, SymbolKeepAspect: c.SymbolKeepAspect}
 	series.ConfigureSeriesOpts(options...)
 	c.MultiSeries = append(c.MultiSeries, series)
 	c.legends = append(c.legends, name)

--- a/charts/series.go
+++ b/charts/series.go
@@ -245,6 +245,7 @@ func WithLineChartOpts(opt opts.LineChart) SeriesOpts {
 		s.YAxisIndex = opt.YAxisIndex
 		s.ConnectNulls = opt.ConnectNulls
 		s.Color = opt.Color
+		s.SymbolKeepAspect = opt.SymbolKeepAspect
 	}
 }
 
@@ -271,6 +272,7 @@ func WithScatterChartOpts(opt opts.ScatterChart) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex
+		s.SymbolKeepAspect = opt.SymbolKeepAspect
 	}
 }
 
@@ -304,6 +306,7 @@ func WithTreeOpts(opt opts.TreeChart) SeriesOpts {
 		s.Left = opt.Left
 		s.Top = opt.Top
 		s.Bottom = opt.Bottom
+		s.SymbolKeepAspect = opt.SymbolKeepAspect
 	}
 }
 

--- a/charts/series.go
+++ b/charts/series.go
@@ -31,6 +31,7 @@ type SingleSeries struct {
 	EdgeLabel          interface{} `json:"edgeLabel,omitempty"`
 	Draggable          bool        `json:"draggable,omitempty"`
 	FocusNodeAdjacency bool        `json:"focusNodeAdjacency,omitempty"`
+	SymbolKeepAspect   bool        `json:"symbolKeepAspect,omitempty"`
 
 	// KLine
 	BarWidth    string `json:"barWidth,omitempty"`
@@ -218,6 +219,7 @@ func WithGraphChartOpts(opt opts.GraphChart) SeriesOpts {
 		s.FocusNodeAdjacency = opt.FocusNodeAdjacency
 		s.Categories = opt.Categories
 		s.EdgeLabel = opt.EdgeLabel
+		s.SymbolKeepAspect = opt.SymbolKeepAspect
 	}
 }
 

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -201,6 +201,9 @@ type GraphChart struct {
 
 	// EdgeLabel is the properties of an label of edge.
 	EdgeLabel *EdgeLabel `json:"edgeLabel"`
+
+	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
+	SymbolKeepAspect bool
 }
 
 // GraphNode represents a data node in graph chart.

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -342,6 +342,9 @@ type LineChart struct {
 
 	// color for Line series. it affects Line series including symbols, unlike LineStyle.Color
 	Color string
+
+	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
+	SymbolKeepAspect bool
 }
 
 // LineChart is the options set for a chandlestick chart.
@@ -524,6 +527,9 @@ type ScatterChart struct {
 
 	// Index of x axis to combine with, which is useful for multiple y axes in one chart.
 	YAxisIndex int
+
+	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
+	SymbolKeepAspect bool
 }
 
 // ScatterData
@@ -645,6 +651,9 @@ type TreeChart struct {
 	Right  string `json:"right,omitempty"`
 	Top    string `json:"top,omitempty"`
 	Bottom string `json:"bottom,omitempty"`
+
+	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
+	SymbolKeepAspect bool
 }
 
 type TreeData struct {

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -488,6 +488,9 @@ type RadarData struct {
 
 	// Value of a single data item.
 	Value interface{} `json:"value,omitempty"`
+
+	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
+	SymbolKeepAspect bool
 }
 
 // SankeyLink represents relationship between two data nodes.

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -488,9 +488,6 @@ type RadarData struct {
 
 	// Value of a single data item.
 	Value interface{} `json:"value,omitempty"`
-
-	// SymbolKeepAspect is whether to keep aspect for symbols in the form of path://.
-	SymbolKeepAspect bool
 }
 
 // SankeyLink represents relationship between two data nodes.


### PR DESCRIPTION
# Description
Supports `symbolkeepAspect` option for graph series.

Fixes #306

---
# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others


---
# Examples:
Are you willing to submit a PR on [go-echarts/Examples](https://github.com/go-echarts/examples)?

- [ ] Yes, I am willing to submit a PR on [Examples](https://github.com/go-echarts/examples)!

