### PR TITLE
Added calendar support

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -28,6 +28,7 @@ type BaseConfiguration struct {
 	opts.RadiusAxis   `json:"radiusAxis"`
 	opts.Brush        `json:"brush"`
 	*opts.AxisPointer `json:"axisPointer"`
+	Calendar          []*opts.Calendar `json:"calendar"`
 
 	render.Renderer        `json:"-"`
 	opts.Initialization    `json:"-"`
@@ -194,6 +195,10 @@ func (bc *BaseConfiguration) json() map[string]interface{} {
 
 	if bc.hasBrush {
 		obj["brush"] = bc.Brush
+	}
+
+	if bc.Calendar != nil {
+		obj["calendar"] = bc.Calendar
 	}
 
 	return obj

--- a/charts/heatmap.go
+++ b/charts/heatmap.go
@@ -37,6 +37,13 @@ func (c *HeatMap) AddSeries(name string, data []opts.HeatMapData, options ...Ser
 	return c
 }
 
+// AddCalendar adds the calendar configuration to the chart.
+func (c *HeatMap) AddCalendar(calendar ...*opts.Calendar) *HeatMap {
+	c.Calendar = append(c.Calendar, calendar...)
+	c.hasXYAxis = false
+	return c
+}
+
 // Validate validates the given configuration.
 func (c *HeatMap) Validate() {
 	c.Assets.Validate(c.AssetsHost)

--- a/charts/series.go
+++ b/charts/series.go
@@ -114,6 +114,9 @@ type SingleSeries struct {
 	*opts.AreaStyle     `json:"areaStyle,omitempty"`
 	*opts.TextStyle     `json:"textStyle,omitempty"`
 	*opts.CircularStyle `json:"circular,omitempty"`
+
+	// Calendar
+	CalendarIndex int `json:"calendarIndex,omitempty"`
 }
 
 type SeriesOpts func(s *SingleSeries)
@@ -121,6 +124,12 @@ type SeriesOpts func(s *SingleSeries)
 func WithCoordinateSystem(cs string) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.CoordSystem = cs
+	}
+}
+
+func WithCalendarIndex(index int) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.CalendarIndex = index
 	}
 }
 

--- a/charts/series.go
+++ b/charts/series.go
@@ -118,6 +118,12 @@ type SingleSeries struct {
 
 type SeriesOpts func(s *SingleSeries)
 
+func WithCoordinateSystem(cs string) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.CoordSystem = cs
+	}
+}
+
 func WithSeriesAnimation(enable bool) SeriesOpts {
 	return func(s *SingleSeries) {
 		s.Animation = enable

--- a/opts/global.go
+++ b/opts/global.go
@@ -1337,8 +1337,8 @@ type Calendar struct {
 	// Height of grid component. Adaptive by default.
 	Height string `json:"height,omitempty"`
 
-	// Specify selected range, that is, the dataValue corresponding to the two handles.
-	Range []float32 `json:"range,omitempty"`
+	// Required, range of Calendar coordinates, support multiple formats.
+	Range []string `json:"range,omitempty"`
 
 	// The size of each rect of calendar coordinates.
 	CellSize string `json:"cellSize,omitempty"`

--- a/opts/global.go
+++ b/opts/global.go
@@ -958,6 +958,13 @@ type VisualMap struct {
 	// bottom value can be instant pixel value like 20; it can also be a percentage
 	// value relative to container width like '20%'.
 	Bottom string `json:"bottom,omitempty"`
+
+	// The layout orientation of legend.
+	// Options: 'horizontal', 'vertical'
+	Orient string `json:"orient,omitempty"`
+
+	// Text style
+	TextStyle *TextStyle `json:"textStyle,omitempty"`
 }
 
 // VisualMapInRange is a visual map instance in a range.
@@ -1188,6 +1195,176 @@ type ParallelAxis struct {
 
 	// Category data，works on (type: "category").
 	Data interface{} `json:"data,omitempty"`
+}
+
+// CalendarLabel is the option set for a calendar label: DayLabel, MonthLabel, YearLabel.
+type CalendarLabel struct {
+	// Whether to show the label.
+	Show bool `json:"show"`
+
+	// The margin between the month label and the axis line.
+	Margin float64 `json:"margin,omitempty"`
+
+	// Position of year.
+	// Default: when orient is set as horizontal, position is left when orient is set as vertical, position is top.
+	// Options: 'left', 'right', 'top', 'bottom'
+	Position string `json:"position,omitempty"`
+
+	// Text color.
+	Color string `json:"color,omitempty"`
+
+	// Font style.
+	// Options: 'normal', 'italic', 'oblique'
+	FontStyle string `json:"fontStyle,omitempty"`
+
+	// Font weight.
+	// Options: 'normal', 'bold', 'bolder', 'lighter', 100 | 200 | 300 | 400...
+	FontWeight string `json:"fontWeight,omitempty"`
+
+	// Font family.
+	FontFamily string `json:"fontFamily,omitempty"`
+
+	// Font size.
+	FontSize int `json:"fontSize,omitempty"`
+
+	// Horizontal alignment of text, automatic by default.
+	// Options: 'left', 'center', 'right'
+	Align string `json:"align,omitempty"`
+
+	// Vertical alignment of text, automatic by default.
+	// Options: 'top', 'middle', 'bottom'
+	VerticalAlign string `json:"verticalAlign,omitempty"`
+
+	// Line height of text.
+	LineHeight int `json:"lineHeight,omitempty"`
+
+	// Background color of label, which is transparent by default.
+	BackgroundColor string `json:"backgroundColor,omitempty"`
+
+	// Border color of label.
+	BorderColor string `json:"borderColor,omitempty"`
+
+	// Border width of label.
+	BorderWidth int `json:"borderWidth,omitempty"`
+
+	// Border radius of label.
+	BorderRadius int `json:"borderRadius,omitempty"`
+
+	// Border type of label.
+	// Options: 'solid', 'dashed', 'dotted'
+	BorderType string `json:"borderType,omitempty"`
+
+	// Border dash offset of label.
+	BorderDashOffset int `json:"borderDashOffset,omitempty"`
+
+	// Padding
+	Padding int `json:"padding,omitempty"`
+
+	// Shadow blur of text block.
+	ShadowBlur int `json:"shadowBlur,omitempty"`
+
+	// Shadow color of text block.
+	ShadowColor string `json:"shadowColor,omitempty"`
+
+	// Shadow X offset of text block.
+	ShadowOffsetX int `json:"shadowOffsetX,omitempty"`
+
+	// Shadow Y offset of text block.
+	ShadowOffsetY int `json:"shadowOffsetY,omitempty"`
+
+	// Width
+	Width int `json:"width,omitempty"`
+
+	// Height
+	Height int `json:"height,omitempty"`
+
+	// Text border color.
+	TextBorderColor string `json:"textBorderColor,omitempty"`
+
+	// Text border width.
+	TextBorderWidth int `json:"textBorderWidth,omitempty"`
+
+	// Text border type
+	// Options: 'solid', 'dashed', 'dotted'
+	TextBorderType string `json:"textBorderType,omitempty"`
+
+	// Text border dash offset.
+	TextBorderDashOffset int `json:"textBorderDashOffset,omitempty"`
+
+	// Text shadow color.
+	TextShadowColor string `json:"textShadowColor,omitempty"`
+
+	// Text shadow blur.
+	TextShadowBlur int `json:"textShadowBlur,omitempty"`
+
+	// Text shadow X offset.
+	TextShadowOffsetX int `json:"textShadowOffsetX,omitempty"`
+
+	// Text shadow Y offset.
+	TextShadowOffsetY int `json:"textShadowOffsetY,omitempty"`
+
+	// Overflow
+	Overflow string `json:"overflow,omitempty"`
+
+	// Ellipsis
+	Ellipsis bool `json:"ellipsis,omitempty"`
+
+	// Silent
+	Silent bool `json:"silent,omitempty"`
+}
+
+// Calendar is the option set for a calendar component.
+// This works with the calendar coordinate system, and it is a heatmap calendar.
+type Calendar struct {
+	ID     string `json:"id,omitempty"`
+	Zlevel int    `json:"zlevel,omitempty"`
+	Z      int    `json:"z,omitempty"`
+	// Distance between grid component and the left side of the container.
+	Left string `json:"left,omitempty"`
+
+	// Distance between grid component and the right side of the container.
+	Right string `json:"right,omitempty"`
+
+	// Distance between grid component and the top side of the container.
+	Top string `json:"top,omitempty"`
+
+	// Distance between grid component and the bottom side of the container.
+	Bottom string `json:"bottom,omitempty"`
+
+	// Width of grid component.
+	Width string `json:"width,omitempty"`
+
+	// Height of grid component. Adaptive by default.
+	Height string `json:"height,omitempty"`
+
+	// Specify selected range, that is, the dataValue corresponding to the two handles.
+	Range []float32 `json:"range,omitempty"`
+
+	// The size of each rect of calendar coordinates.
+	CellSize string `json:"cellSize,omitempty"`
+
+	// The layout orientation of legend.
+	// Options: 'horizontal', 'vertical'
+	Orient string `json:"orient,omitempty"`
+
+	// Split line of X axis in grid area.
+	SplitLine *SplitLine `json:"splitLine,omitempty"`
+
+	// Graphic style of Map Area Border, emphasis is the style when it is highlighted,
+	// like being hovered by mouse, or highlighted via legend connect.
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
+
+	// Day Label
+	DayLabel *CalendarLabel `json:"dayLabel,omitempty"`
+
+	// Month Label
+	MonthLabel *CalendarLabel `json:"monthLabel,omitempty"`
+
+	// Year Label
+	YearLabel *CalendarLabel `json:"yearLabel,omitempty"`
+
+	// Whether to ignore mouse events. Default value is false, for triggering and responding to mouse events.
+	Silent bool `json:"silent,omitempty"`
 }
 
 // Polar Bar options

--- a/types/orderedset_test.go
+++ b/types/orderedset_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOrderedSet(t *testing.T) {

--- a/types/orderedset_test.go
+++ b/types/orderedset_test.go
@@ -1,9 +1,8 @@
 package types
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestOrderedSet(t *testing.T) {


### PR DESCRIPTION
# Description

The library only supports the traditional heatmap. echarts supports also the [calendar variation](https://echarts.apache.org/examples/en/editor.html?c=calendar-heatmap).

I added the support for the calendar. It's now possible to add multiple series and multiple calendars

---
# Type of change

- [X] New feature (Non-breaking change which adds functionality)

---
# Examples

This is how I use it go potentially generate a set of multiple calendars per year. After the code you can find the generated calendar (only for 1 year).

```go
	var dailyStepsPerYear map[int][]opts.HeatMapData = make(map[int][]opts.HeatMapData)
	var maxSteps int = 0
	for _, dayData := range all {
		if dayData == nil || dayData.Steps == nil {
			continue
		}
		step := int(dayData.Steps.Value)
		if step > maxSteps {
			maxSteps = step
		}
		// format date to YYYY-MM-DD
		value := [2]interface{}{dayData.Date.Format(time.DateOnly), step}
		year := dayData.Date.Year()
		dailyStepsPerYear[year] = append(dailyStepsPerYear[year], opts.HeatMapData{Value: value, Name: dayData.Date.Format(time.DateOnly)})
	}
	chart := charts.NewHeatMap()

	chart.SetGlobalOptions(
		charts.WithTitleOpts(opts.Title{
			Title: "Daily Steps Count",`
			Top:   "30",
			Left:  "center",
		}),
		charts.WithInitializationOpts(opts.Initialization{
			Theme: "dark",
		}),
		charts.WithTooltipOpts(opts.Tooltip{
			Trigger: "item",
			Show:    true,
		}),
		charts.WithVisualMapOpts(
			opts.VisualMap{
				Type:   "piecewise",
				Min:    0,
				Max:    float32(maxSteps),
				Show:   true,
				Orient: "horizontal",
				Left:   "center",
				Top:    "65",
				TextStyle: &opts.TextStyle{
					Color: "white",
				},
			}),
		charts.WithLegendOpts(opts.Legend{
			Show: false,
		}),
	)

	years := make([]int, 0, len(dailyStepsPerYear))
	for k := range dailyStepsPerYear {
		years = append(years, k)
	}

	sort.Ints(years)

	verticalOffset := 120
	for id, year := range years {
		chart.AddSeries("Daily Steps", dailyStepsPerYear[year],
			charts.WithCoordinateSystem("calendar"),
			charts.WithCalendarIndex(id),
		)
		chart.AddCalendar(&opts.Calendar{
			Orient:   "horizontal",
			Silent:   false,
			Range:    []float32{float32(year)},
			Top:      fmt.Sprintf("%d", 120+id*verticalOffset),
			Left:     "30",
			Right:    "30",
			CellSize: "15",
			ItemStyle: &opts.ItemStyle{
				BorderWidth: 0.5,
			},
			YearLabel: &opts.CalendarLabel{
				Show: true,
			},
			DayLabel: &opts.CalendarLabel{
				Show:  true,
				Color: "white",
			},
			MonthLabel: &opts.CalendarLabel{
				Show:  true,
				Color: "white",
			},
		})
	}

	return chart
}
```

![image](https://github.com/go-echarts/go-echarts/assets/8427788/7e4c58f4-fe3f-4eb8-8241-f9df92d1571c)
