### PR TITLE
Add nameGap to x and y axis options

### DIFF
--- a/opts/global.go
+++ b/opts/global.go
@@ -693,6 +693,9 @@ type XAxis struct {
 	// 'end'
 	NameLocation string `json:"nameLocation,omitempty"`
 
+	// Gap between axis name and axis line.
+	NameGap int `json:"nameGap,omitempty"`
+
 	// Type of axis.
 	// Option:
 	// * 'value': Numerical axis, suitable for continuous data.
@@ -772,6 +775,9 @@ type YAxis struct {
 	// 'middle' or 'center'
 	// 'end'
 	NameLocation string `json:"nameLocation,omitempty"`
+
+	// Gap between axis name and axis line.
+	NameGap int `json:"nameGap,omitempty"`
 
 	// Type of axis.
 	// Option:


### PR DESCRIPTION
# Description

Adds `nameGap` to x and y axis options.

Fixes #323.

# Type of change

- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others

