### PR TITLE
fix: page config mess up with chart

### DIFF
--- a/components/page.go
+++ b/components/page.go
@@ -3,6 +3,7 @@ package components
 import (
 	"github.com/go-echarts/go-echarts/v2/opts"
 	"github.com/go-echarts/go-echarts/v2/render"
+	"github.com/go-echarts/go-echarts/v2/util"
 )
 
 type Layout string
@@ -26,7 +27,7 @@ type Charter interface {
 // Page represents a page chart.
 type Page struct {
 	render.Renderer
-	opts.Initialization
+	opts.PageConfiguration
 	opts.Assets
 
 	Charts []Charter
@@ -42,13 +43,23 @@ func NewPage() *Page {
 	return page
 }
 
+func (page *Page) SetPageTitle(title string) *Page {
+	page.PageConfiguration.PageTitle = title
+	return page
+}
+
+func (page *Page) SetAssetsHost(assetsHost string) *Page {
+	page.PageConfiguration.AssetsHost = assetsHost
+	return page
+}
+
 // SetLayout sets the layout of the Page.
 func (page *Page) SetLayout(layout Layout) *Page {
 	page.Layout = layout
 	return page
 }
 
-// AddCharts adds new charts to the page.
+// AddCharts adds new charts to the page and merge assets.
 func (page *Page) AddCharts(charts ...Charter) *Page {
 	for i := 0; i < len(charts); i++ {
 		assets := charts[i].GetAssets()
@@ -67,6 +78,6 @@ func (page *Page) AddCharts(charts ...Charter) *Page {
 
 // Validate validates the given configuration.
 func (page *Page) Validate() {
-	page.Initialization.Validate()
+	util.SetDefaultValue(page)
 	page.Assets.Validate(page.AssetsHost)
 }

--- a/opts/global.go
+++ b/opts/global.go
@@ -13,10 +13,17 @@ const (
 	CompatibleEchartsJS = "echarts@4.min.js"
 )
 
-// Initialization contains options for the canvas.
-type Initialization struct {
+type PageConfiguration struct {
 	// HTML title
 	PageTitle string `default:"Awesome go-echarts"`
+	// Assets host
+	AssetsHost string `default:"https://go-echarts.github.io/go-echarts-assets/assets/"`
+	// Custom host
+	CustomAssetsHost string
+}
+
+// Initialization contains options for the canvas.
+type Initialization struct {
 
 	// Width of canvas
 	Width string `default:"900px"`
@@ -30,17 +37,18 @@ type Initialization struct {
 	// Chart unique ID
 	ChartID string
 
-	// Assets host
-	AssetsHost string `default:"https://go-echarts.github.io/go-echarts-assets/assets/"`
-
-	// Custom host
-	CustomAssetsHost string
-
 	// Theme of chart
 	Theme string `default:"white"`
 
 	// Renderer
 	Renderer string `default:"canvas"`
+
+	// Page configurations duplicate, a shortcut for single chart build with page settings
+	PageTitle string `default:"Awesome go-echarts"`
+	// Assets host
+	AssetsHost string `default:"https://go-echarts.github.io/go-echarts-assets/assets/"`
+	// Custom host
+	CustomAssetsHost string
 }
 
 // Validate validates the initialization configurations.


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

> Please share your ideas and awesome changes to let us know more

Since the `page` and `chart` have the same `opts.Initialization`, it get misunderstanding easily.
Changes:
- Move the Page's config as `PageConfiguration`. Charts' options is invisible for page.
- Keep it duplicated page config in `opts.Initialization` instead nest `PageConfiguration` for compatibility.


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->
 close #355 
---

# Type of change

- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Others

<!-- details -->




