### PR TITLE
feat(gauge): add options 'progress', 'axistick' and 'detail'

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -662,24 +662,3 @@ func WithCustomChartOpts(opt opts.CustomChart) SeriesOpts {
 		s.RenderItem = opt.RenderItem
 	}
 }
-
-// WithProgressOpts sets the Progress option.
-func WithProgressOpts(opt opts.Progress) SeriesOpts {
-	return func(s *SingleSeries) {
-		s.Progress = &opt
-	}
-}
-
-// WithAxisTickOpts sets the AxisTick option.
-func WithAxisTickOpts(opt opts.AxisTick) SeriesOpts {
-	return func(s *SingleSeries) {
-		s.AxisTick = &opt
-	}
-}
-
-// WithDetailsOpts sets the Detail option.
-func WithDetailOpts(opt opts.Detail) SeriesOpts {
-	return func(s *SingleSeries) {
-		s.Detail = &opt
-	}
-}

--- a/charts/series.go
+++ b/charts/series.go
@@ -133,7 +133,7 @@ type SingleSeries struct {
 	UseUTC              types.Bool `json:"useUTC,omitempty"`
 
 	// Animation related configs
-	Animation               types.Bool `json:"animation,omitempty"               default:"true"`
+	Animation               types.Bool `json:"animation,omitempty"`
 	AnimationThreshold      int        `json:"animationThreshold,omitempty"`
 	AnimationDuration       int        `json:"animationDuration,omitempty"`
 	AnimationEasing         string     `json:"animationEasing,omitempty"`

--- a/charts/series.go
+++ b/charts/series.go
@@ -120,6 +120,11 @@ type SingleSeries struct {
 	Data         interface{} `json:"data,omitempty"`
 	DatasetIndex int         `json:"datasetIndex,omitempty"`
 
+	// Gauge
+	Progress *opts.Progress `json:"progress,omitempty"`
+	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
+	Detail   *opts.Detail  `json:"detail,omitempty"`
+
 	// Shared below =====================================================
 	Large               types.Bool `json:"large,omitempty"`
 	LargeThreshold      int        `json:"largeThreshold,omitempty"`
@@ -127,7 +132,7 @@ type SingleSeries struct {
 	UseUTC              types.Bool `json:"useUTC,omitempty"`
 
 	// Animation related configs
-	Animation               types.Bool `json:"animation,omitempty" default:"true"`
+	Animation               types.Bool `json:"animation,omitempty"               default:"true"`
 	AnimationThreshold      int        `json:"animationThreshold,omitempty"`
 	AnimationDuration       int        `json:"animationDuration,omitempty"`
 	AnimationEasing         string     `json:"animationEasing,omitempty"`
@@ -655,5 +660,26 @@ func WithCustomChartOpts(opt opts.CustomChart) SeriesOpts {
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex
 		s.RenderItem = opt.RenderItem
+	}
+}
+
+// WithProgressOpts sets the Progress option.
+func WithProgressOpts(opt opts.Progress) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.Progress = &opt
+	}
+}
+
+// WithAxisTickOpts sets the AxisTick option.
+func WithAxisTickOpts(opt opts.AxisTick) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.AxisTick = &opt
+	}
+}
+
+// WithDetailsOpts sets the Detail option.
+func WithDetailOpts(opt opts.Detail) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.Detail = &opt
 	}
 }

--- a/charts/series.go
+++ b/charts/series.go
@@ -123,7 +123,7 @@ type SingleSeries struct {
 	// Gauge
 	Progress *opts.Progress `json:"progress,omitempty"`
 	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
-	Detail   *opts.Detail  `json:"detail,omitempty"`
+	Detail   *opts.Detail   `json:"detail,omitempty"`
 
 	// Shared below =====================================================
 	Large               types.Bool `json:"large,omitempty"`
@@ -132,7 +132,7 @@ type SingleSeries struct {
 	UseUTC              types.Bool `json:"useUTC,omitempty"`
 
 	// Animation related configs
-	Animation               types.Bool `json:"animation,omitempty"`
+	Animation               types.Bool `json:"animation,omitempty"               default:"true"`
 	AnimationThreshold      int        `json:"animationThreshold,omitempty"`
 	AnimationDuration       int        `json:"animationDuration,omitempty"`
 	AnimationEasing         string     `json:"animationEasing,omitempty"`

--- a/charts/series.go
+++ b/charts/series.go
@@ -124,6 +124,7 @@ type SingleSeries struct {
 	Progress *opts.Progress `json:"progress,omitempty"`
 	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
 	Detail   *opts.Detail   `json:"detail,omitempty"`
+	Title    *opts.Title    `json:"title,omitempty"`
 
 	// Shared below =====================================================
 	Large               types.Bool `json:"large,omitempty"`

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -636,7 +636,7 @@ type Detail struct {
 	// as string) or a percentage.
 	// Positive values move the chart value to [right, bottom], negative values vice
 	// versa.
-	OffsetCenter [2]string `json:"offsetCenter,omitempty"`
+	OffsetCenter []string `json:"offsetCenter,omitempty"`
 }
 
 // CustomData

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -608,6 +608,37 @@ type CustomChart struct {
 	RenderItem types.FuncStr
 }
 
+// Progress is the options set for progress.
+type Progress struct {
+	// Wether to show the progress
+	Show types.Bool `json:"show,omitempty"`
+	// Width of the progress in px
+	Width int `json:"width,omitempty"`
+}
+
+// Detail is the options set for detail (e.g. on a gauge).
+type Detail struct {
+	// The content formatter of value
+	//
+	// 1. String template
+	// The template variable is {value}.
+	//
+	// 2. Callback function
+	// The format of callback function:
+	// (value: number) => string
+	Formatter types.FuncStr `json:"formatter,omitempty"`
+
+	// Font size of the value in px
+	FontSize int `json:"fontSize,omitempty"`
+
+	// Value position relative to the center of chart
+	// OffceCenter is provided as [x, y] where x and y are either a number (px, provided
+    // as string) or a percentage.
+	// Positive values move the chart value to [right, bottom], negative values vice
+	// versa.
+	OffsetCenter [2]string `json:"offsetCenter,omitempty"`
+}
+
 // CustomData
 // https://echarts.apache.org/en/option.html#series-custom.data
 type CustomData struct {

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -633,7 +633,7 @@ type Detail struct {
 
 	// Value position relative to the center of chart
 	// OffceCenter is provided as [x, y] where x and y are either a number (px, provided
-    // as string) or a percentage.
+	// as string) or a percentage.
 	// Positive values move the chart value to [right, bottom], negative values vice
 	// versa.
 	OffsetCenter [2]string `json:"offsetCenter,omitempty"`

--- a/opts/title.go
+++ b/opts/title.go
@@ -79,4 +79,11 @@ type Title struct {
 	// borderRadius: [5, 5, 0, 0] // (clockwise upper left, upper right, bottom right and bottom left)
 	// FYI, use [1] is same to number 1
 	BorderRadius []int `json:"borderRadius,omitempty"`
+
+	// Value position relative to the center of chart
+	// OffceCenter is provided as [x, y] where x and y are either a number (px, provided
+	// as string) or a percentage.
+	// Positive values move the chart value to [right, bottom], negative values vice
+	// versa.
+	OffsetCenter [2]string `json:"offsetCenter,omitempty"`
 }

--- a/opts/title.go
+++ b/opts/title.go
@@ -85,5 +85,5 @@ type Title struct {
 	// as string) or a percentage.
 	// Positive values move the chart value to [right, bottom], negative values vice
 	// versa.
-	OffsetCenter [2]string `json:"offsetCenter,omitempty"`
+	OffsetCenter []string `json:"offsetCenter,omitempty"`
 }


### PR DESCRIPTION
# Description

Add options to create a gauge chart like this:

<img src="https://github.com/go-echarts/go-echarts/assets/3276460/e97a0bbb-894c-4630-aa99-002028055874" width="150">

It is inspired by this: https://echarts.apache.org/examples/en/editor.html?c=gauge-speed

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

The following options are now available for a gauge chart:
- Progress
- AxisTick (settings this on XAsis does not work)
- Detail

---

Once this PR is merged, I will create a PR for the examples repo.