### PR TITLE
Add RenderSnippet to Renderer to facilitate their embedding within other templates

### DIFF
--- a/render/chart.go
+++ b/render/chart.go
@@ -40,3 +40,29 @@ func (r *chartRender) RenderContent() []byte {
 
 	return pat.ReplaceAll(buf.Bytes(), []byte(""))
 }
+
+func (r *chartRender) RenderSnippet() ChartSnippet {
+	for _, fn := range r.before {
+		fn()
+	}
+
+	elementTpl := MustTemplate(ModChart, []string{templates.BaseTpl, templates.BaseElementTpl})
+
+	var snippet ChartSnippet
+	var elementBuf bytes.Buffer // Buffer to collect template output
+
+	if err := elementTpl.ExecuteTemplate(&elementBuf, ModChart, r.c); err != nil {
+		panic(err)
+	}
+	snippet.Element = string(pat.ReplaceAll(elementBuf.Bytes(), []byte("")))
+
+	scriptTpl := MustTemplate(ModChart, []string{templates.BaseTpl, templates.BaseScriptTpl})
+	var scriptBuf bytes.Buffer // Buffer to collect template output
+
+	if err := scriptTpl.ExecuteTemplate(&scriptBuf, ModChart, r.c); err != nil {
+		panic(err)
+	}
+	snippet.Script = string(pat.ReplaceAll(scriptBuf.Bytes(), []byte("")))
+
+	return snippet
+}

--- a/render/engine.go
+++ b/render/engine.go
@@ -22,12 +22,18 @@ const (
 
 var pat = regexp.MustCompile(`(__f__")|("__f__)|(__f__)`)
 
+type ChartSnippet struct {
+	Element string
+	Script  string
+}
+
 // Renderer
 // Any kinds of charts have their render implementation and
 // you can define your own render logic easily.
 type Renderer interface {
 	Render(w io.Writer) error
 	RenderContent() []byte
+	RenderSnippet() ChartSnippet
 }
 
 // isSet check if the field exist in the chart instance

--- a/render/page.go
+++ b/render/page.go
@@ -39,3 +39,29 @@ func (r *pageRender) RenderContent() []byte {
 
 	return pat.ReplaceAll(buf.Bytes(), []byte(""))
 }
+
+func (r *pageRender) RenderSnippet() ChartSnippet {
+	for _, fn := range r.before {
+		fn()
+	}
+
+	elementTpl := MustTemplate(ModPage, []string{templates.BaseTpl, templates.BaseElementTpl, templates.BaseElementsTpl})
+
+	var snippet ChartSnippet
+	var elementBuf bytes.Buffer
+
+	if err := elementTpl.ExecuteTemplate(&elementBuf, ModPage, r.c); err != nil {
+		panic(err)
+	}
+	snippet.Element = string(pat.ReplaceAll(elementBuf.Bytes(), []byte("")))
+
+	scriptTpl := MustTemplate(ModPage, []string{templates.BaseTpl, templates.BaseScriptTpl, templates.BaseScriptsTpl})
+	var scriptBuf bytes.Buffer
+
+	if err := scriptTpl.ExecuteTemplate(&scriptBuf, ModPage, r.c); err != nil {
+		panic(err)
+	}
+	snippet.Script = string(pat.ReplaceAll(scriptBuf.Bytes(), []byte("")))
+
+	return snippet
+}

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -1,8 +1,10 @@
-{{- define "base" }}
+{{- define "base_element" -}}
 <div class="container">
     <div class="item" id="{{ .ChartID }}" style="width:{{ .Initialization.Width }};height:{{ .Initialization.Height }};"></div>
 </div>
+{{- end -}}
 
+{{- define "base_script" -}}
 <script type="text/javascript">
     "use strict";
     let goecharts_{{ .ChartID | safeJS }} = echarts.init(document.getElementById('{{ .ChartID | safeJS }}'), "{{ .Theme }}", { renderer: "{{  .Initialization.Renderer }}" });
@@ -21,4 +23,9 @@
     {{ injectInstance . "%MY_ECHARTS%"  $.ChartID  | safeJS }}
     {{- end }}
 </script>
-{{ end }}
+{{- end -}}
+
+{{- define "base" }}
+    {{- template "base_element" . }}
+    {{- template "base_script" . }}
+{{- end }}

--- a/templates/base_element.tpl
+++ b/templates/base_element.tpl
@@ -1,0 +1,2 @@
+{{template "base_element" .}}
+    

--- a/templates/base_elements.tpl
+++ b/templates/base_elements.tpl
@@ -1,0 +1,1 @@
+{{- range .Charts }} {{ template "base_element" . }} {{- end }}

--- a/templates/base_script.tpl
+++ b/templates/base_script.tpl
@@ -1,0 +1,1 @@
+{{template "base_script" .}}

--- a/templates/base_scripts.tpl
+++ b/templates/base_scripts.tpl
@@ -1,0 +1,3 @@
+{{range .Charts }} 
+    {{- template "base_script" . }} 
+{{end }}

--- a/templates/template.go
+++ b/templates/template.go
@@ -15,3 +15,15 @@ var HeaderTpl string
 
 //go:embed page.tpl
 var PageTpl string
+
+//go:embed base_element.tpl
+var BaseElementTpl string
+
+//go:embed base_elements.tpl
+var BaseElementsTpl string
+
+//go:embed base_script.tpl
+var BaseScriptTpl string
+
+//go:embed base_scripts.tpl
+var BaseScriptsTpl string


### PR DESCRIPTION
# Description
Recently I was using go-echarts in one of my projects and I would have liked it if It was possible to embed my charts into custom templates, but I couldn't find a straightforward way to achieve this. I found this [article](https://blog.cubieserver.de/2020/how-to-render-standalone-html-snippets-with-go-echarts/) that talks about the same problem with go-echarts and solves it by implementing a custom renderer. I find it strange that there isn't a built-in way to do this, considering that embedding charts instead of firing a standalone HTTP page or using iframes is expected by most users in production.
I have a simple implementation to do this by adding a RenderSnippet function to the Renderer interface, which is a charm when working only with charts. But the only problem is that both pageRender & chartRender use the same Renderer interface and defining the correct behavior for this method in PageRender can be a little tricky. I've solved it by collecting all elements & scripts in singular fields. 

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

---

# Example
```go
package main

import (
	"math/rand"
	"os"
	"text/template"

	"github.com/go-echarts/go-echarts/v2/charts"
	"github.com/go-echarts/go-echarts/v2/opts"
)

// generate random data for bar chart
func generateBarItems() []opts.BarData {
	items := make([]opts.BarData, 0)
	for i := 0; i < 7; i++ {
		items = append(items, opts.BarData{Value: rand.Intn(300)})
	}
	return items
}

func main() {
	// create a new bar instance
	bar := charts.NewBar()
	// set some global options like Title/Legend/ToolTip or anything else
	bar.SetGlobalOptions(charts.WithTitleOpts(opts.Title{
		Title:    "My first bar chart generated by go-echarts",
		Subtitle: "It's extremely easy to use, right?",
	}))

	// Put data into instance
	bar.SetXAxis([]string{"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}).
		AddSeries("Category A", generateBarItems()).
		AddSeries("Category B", generateBarItems())

	// Render chartSnippet that has Element & Script fields
	chartSnippet := bar.RenderSnippet()

	// Embedd element & script into a cusotm template
	tmpl := "{{.Element}}{{.Script}}"
	t := template.New("snippet")
	t, err := t.Parse(tmpl)
	if err != nil {
		panic(err)
	}

	err = t.Execute(os.Stdout, chartSnippet)
	if err != nil {
		panic(err)
	}
}
```

---
