### PR TITLE
Allow setting minimum/maximum values for gauge

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -125,6 +125,8 @@ type SingleSeries struct {
 	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
 	Detail   *opts.Detail   `json:"detail,omitempty"`
 	Title    *opts.Title    `json:"title,omitempty"`
+	MinValue int            `json:"min,omitempty"`
+	MaxValue int            `json:"max,omitempty"`
 
 	Large               types.Bool `json:"large,omitempty"`
 	LargeThreshold      int        `json:"largeThreshold,omitempty"`
@@ -660,5 +662,12 @@ func WithCustomChartOpts(opt opts.CustomChart) SeriesOpts {
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex
 		s.RenderItem = opt.RenderItem
+	}
+}
+
+func WithGaugeOpts(opt opts.Gauge) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.MinValue = opt.MinValue
+		s.MaxValue = opt.MaxValue
 	}
 }

--- a/opts/gauge.go
+++ b/opts/gauge.go
@@ -1,0 +1,6 @@
+package opts
+
+type Gauge struct {
+	MinValue int `json:"min,omitempty"`
+	MaxValue int `json:"max,omitempty"`
+}


### PR DESCRIPTION
# Description

This PR adds the ability to set the minimum and maximum values for Gauge charts.

```
gauge := charts.NewGauge()
gauge.SetGlobalOptions(
    charts.WithTitleOpts(opts.Title{Title: "Basic Gauge example"}),
)
gauge.AddSeries("Solar Panels", []opts.GaugeData{{Name: "PV Generation", Value: rand.Intn(3500)}}).
    SetSeriesOptions(
        charts.WithGaugeOpts(opts.Gauge{MinValue: 0, MaxValue: 3500}),
)
```
---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others