### PR TITLE
update: add series options Min Max.

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -125,8 +125,8 @@ type SingleSeries struct {
 	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
 	Detail   *opts.Detail   `json:"detail,omitempty"`
 	Title    *opts.Title    `json:"title,omitempty"`
-	MinValue int            `json:"min,omitempty"`
-	MaxValue int            `json:"max,omitempty"`
+	Min      int            `json:"min,omitempty"`
+	Max      int            `json:"max,omitempty"`
 
 	Large               types.Bool `json:"large,omitempty"`
 	LargeThreshold      int        `json:"largeThreshold,omitempty"`
@@ -662,12 +662,5 @@ func WithCustomChartOpts(opt opts.CustomChart) SeriesOpts {
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex
 		s.RenderItem = opt.RenderItem
-	}
-}
-
-func WithGaugeOpts(opt opts.Gauge) SeriesOpts {
-	return func(s *SingleSeries) {
-		s.MinValue = opt.MinValue
-		s.MaxValue = opt.MaxValue
 	}
 }

--- a/charts/series.go
+++ b/charts/series.go
@@ -125,6 +125,8 @@ type SingleSeries struct {
 	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
 	Detail   *opts.Detail   `json:"detail,omitempty"`
 	Title    *opts.Title    `json:"title,omitempty"`
+	MinValue int            `json:"min,omitempty"`
+	MaxValue int            `json:"max,omitempty"`
 
 	Large               types.Bool `json:"large,omitempty"`
 	LargeThreshold      int        `json:"largeThreshold,omitempty"`
@@ -660,5 +662,12 @@ func WithCustomChartOpts(opt opts.CustomChart) SeriesOpts {
 		s.XAxisIndex = opt.XAxisIndex
 		s.YAxisIndex = opt.YAxisIndex
 		s.RenderItem = opt.RenderItem
+	}
+}
+
+func WithGaugeOpts(opt opts.Gauge) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.MinValue = opt.MinValue
+		s.MaxValue = opt.MaxValue
 	}
 }

--- a/opts/gauge.go
+++ b/opts/gauge.go
@@ -1,0 +1,6 @@
+package opts
+
+type Gauge struct {
+	MinValue int `json:"min,omitempty"`
+	MaxValue int `json:"max,omitempty"`
+}

--- a/opts/gauge.go
+++ b/opts/gauge.go
@@ -1,6 +1,0 @@
-package opts
-
-type Gauge struct {
-	MinValue int `json:"min,omitempty"`
-	MaxValue int `json:"max,omitempty"`
-}


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

Add the `Min`/`Max` config in series, specially for Gauge now. see #419 
With the `WithSeriesOpts` helper to achieve it for now. need restructure the series of Gauge later.

> Please share your ideas and awesome changes to let us know more :)


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

