### PR TITLE
fix(options): allow set markline style per data

### DIFF
--- a/opts/series.go
+++ b/opts/series.go
@@ -236,6 +236,8 @@ type MarkLineNameTypeItem struct {
 	// It may be the direct name of a dimension, like x,
 	// or angle for line charts, or open, or close for candlestick charts.
 	ValueDim string `json:"valueDim,omitempty"`
+
+	LineStyle *LineStyle `json:"lineStyle,omitempty"`
 }
 
 // MarkLineNameYAxisItem defines a MarkLine on a Y axis.


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

> Please share your ideas and awesome changes to let us know more :)

As discussed in #456 .
It is missing config the mark line style per data:
```js
option = {
  tooltip: {},
  legend: {},
  xAxis: {
    data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
  },
  yAxis: {},
  series: [{
    name: "Sale",
    type: "bar",
    data: [5, 20, 36, 10, 10, 20, 4],
    markLine: {
      data: [{
        type: "average",
     // here
        lineStyle: {
        color: "rgba(105, 36, 36, 1)"
      }
      },{
        type: "max"
      }],
      
    }
  }]
}
```
<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

