### PR TITLE
Style config for Graph elements

### DIFF
--- a/opts/charts.go
+++ b/opts/charts.go
@@ -225,6 +225,9 @@ type GraphLink struct {
 
 	// Label for this link.
 	Label *EdgeLabel `json:"label,omitempty"`
+
+	// LineStyle settings in this series data.
+	LineStyle *LineStyle `json:"lineStyle,omitempty"`
 }
 
 // GraphCategory represents a category for data nodes.
@@ -235,6 +238,9 @@ type GraphLink struct {
 type GraphCategory struct {
 	// Name of category, which is used to correspond with legend and the content of tooltip.
 	Name string `json:"name"`
+
+	// The style of this node.
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 
 	// The label style of node in this category.
 	Label *Label `json:"label,omitempty"`


### PR DESCRIPTION
# Description

echarts.apache.org support customization of styles for Graph edges, Graph Category nodes, etc.
- https://echarts.apache.org/en/option.html#series-graph.links
- https://echarts.apache.org/en/option.html#series-graph.categories

The change allows advance visualisation of graphs:
<img width="858" alt="Screenshot 2024-07-19 at 23 40 24" src="https://github.com/user-attachments/assets/b47aadad-6e6d-433c-877a-b7bc7f19c07e">

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

---
