### PR TITLE
update(opt): add position of area config

### DIFF
--- a/opts/series.go
+++ b/opts/series.go
@@ -502,6 +502,16 @@ type AreaStyle struct {
 	// Fill area color.
 	Color string `json:"color,omitempty"`
 
+	// Origin position of area.
+	// By default, the area between axis line and data will be filled.
+	// This config enables you to fill the area from data to the max or min of the axis data or a specified value.
+	// Valid values:
+	// 'auto' to fill between axis line and data (Default)
+	// 'start' to fill between min axis value (when not inverse) and data
+	// 'end' to fill between max axis value (when not inverse) and data
+	//  number to fill between specified value and data
+	Origin string `json:"origin,omitempty"`
+
 	// Opacity of the component. Supports value from 0 to 1, and the component will not be drawn when set to 0.
 	Opacity float32 `json:"opacity,omitempty"`
 }


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

> Please share your ideas and awesome changes to let us know more :)

	// Origin position of area.
	// By default, the area between axis line and data will be filled.
	// This config enables you to fill the area from data to the max or min of the axis data or a specified value.
	// Valid values:
	// 'auto' to fill between axis line and data (Default)
	// 'start' to fill between min axis value (when not inverse) and data
	// 'end' to fill between max axis value (when not inverse) and data
	//  number to fill between specified value and data

<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

