### PR TITLE
radar start angle option

### DIFF
--- a/opts/radar.go
+++ b/opts/radar.go
@@ -27,7 +27,7 @@ type RadarComponent struct {
 	AxisLine *AxisLine `json:"axisLine,omitempty"`
 
 	// The start angle of coordinate, which is the angle of the first indicator axis.
-	StartAngle float64 `json:"startAngle,omitempty"`
+	StartAngle int `json:"startAngle,omitempty"`
 }
 
 // Indicator is the option set for a radar chart.

--- a/opts/radar.go
+++ b/opts/radar.go
@@ -25,6 +25,9 @@ type RadarComponent struct {
 
 	// AxisLine controls settings related to axis line.
 	AxisLine *AxisLine `json:"axisLine,omitempty"`
+
+	// The start angle of coordinate, which is the angle of the first indicator axis.
+	StartAngle float64 `json:"startAngle,omitempty"`
 }
 
 // Indicator is the option set for a radar chart.


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

add startAngle option.

```go
package main

import (
	"os"

	"github.com/go-echarts/go-echarts/v2/charts"
	"github.com/go-echarts/go-echarts/v2/opts"
)

var indicators = []*opts.Indicator{
	{Name: "AQI", Max: 300},
	{Name: "PM2.5", Max: 250},
	{Name: "PM10", Max: 300},
	{Name: "CO", Max: 5},
	{Name: "NO2", Max: 200},
	{Name: "SO2", Max: 100},
}

func main() {
	radar := charts.NewRadar()
	radar.SetGlobalOptions(
		charts.WithTitleOpts(opts.Title{
			Title: "basic radar example",
		}),
		charts.WithRadarComponentOpts(opts.RadarComponent{
			Indicator:  indicators,
			SplitArea:  &opts.SplitArea{Show: opts.Bool(true)},
			SplitLine:  &opts.SplitLine{Show: opts.Bool(true)},
			AxisLine:   &opts.AxisLine{Show: opts.Bool(false)},
			StartAngle: 45,
		}),
	)
	radar.AddSeries("Data", []opts.RadarData{{Value: []int{57, 31, 54, 1, 32, 14, 19}}})
	// Where the magic happens
	f, _ := os.Create("radar.html")
	radar.Render(f)
}
```

> Please share your ideas and awesome changes to let us know more :)


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

