### PR TITLE
update(opt): Add new fields to the TextStyle/Progress/Detail structure.

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -121,12 +121,18 @@ type SingleSeries struct {
 	DatasetIndex int         `json:"datasetIndex,omitempty"`
 
 	// Gauge
-	Progress *opts.Progress `json:"progress,omitempty"`
-	AxisTick *opts.AxisTick `json:"axisTick,omitempty"`
-	Detail   *opts.Detail   `json:"detail,omitempty"`
-	Title    *opts.Title    `json:"title,omitempty"`
-	Min      int            `json:"min,omitempty"`
-	Max      int            `json:"max,omitempty"`
+	Progress   *opts.Progress  `json:"progress,omitempty"`
+	AxisTick   *opts.AxisTick  `json:"axisTick,omitempty"`
+	AxisLabel  *opts.AxisLabel `json:"axisLabel,omitempty"`
+	AxisLine   *opts.AxisLine  `json:"axisLine,omitempty"`
+	Pointer    *opts.Pointer   `json:"pointer,omitempty"`
+	SplitLine  *opts.SplitLine `json:"splitLine,omitempty"`
+	Detail     *opts.Detail    `json:"detail,omitempty"`
+	Title      *opts.Title     `json:"title,omitempty"`
+	Min        int             `json:"min,omitempty"`
+	Max        int             `json:"max,omitempty"`
+	StartAngle float64         `json:"startAngle,omitempty"`
+	EndAngle   float64         `json:"endAngle,omitempty"`
 
 	Large               types.Bool `json:"large,omitempty"`
 	LargeThreshold      int        `json:"largeThreshold,omitempty"`

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -529,14 +529,133 @@ type CustomChart struct {
 
 // Progress is the options set for progress.
 type Progress struct {
-	// Wether to show the progress
+	// Whether to show the progress, default is false.
 	Show types.Bool `json:"show,omitempty"`
+
+	// Whether the progress overlaps when there are multiple groups of data, default is true.
+	OverLap types.Bool `json:"overlap,omitempty"`
+
 	// Width of the progress in px
 	Width int `json:"width,omitempty"`
+
+	// Whether to add round caps at the end, default is false.
+	RoundCap types.Bool `json:"roundCap,omitempty"`
+
+	// Whether to clip overflow, default is false.
+	Clip types.Bool `json:"clip,omitempty"`
+
+	// The style of progress.
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
 }
 
 // Detail is the options set for detail (e.g. on a gauge).
 type Detail struct {
+	// Whether to show the details, default is true.
+	Show types.Bool `json:"show,omitempty"`
+
+	// Font color
+	Color string `json:"color,omitempty"`
+
+	// Font style
+	// Options: 'normal', 'italic', 'oblique'
+	FontStyle string `json:"fontStyle,omitempty"`
+
+	// FontWeight main title font thick weight.
+	// Options are:
+	// 'normal'
+	// 'bold'
+	// 'bolder'
+	// 'lighter'
+	// 100 | 200 | 300 | 400...
+	FontWeight string `json:"fontWeight,omitempty"`
+
+	// Font family the main title font family.
+	// Options: "sans-serif", 'serif' , 'monospace', 'Arial', 'Courier New', 'Microsoft YaHei', ...
+	FontFamily string `json:"fontFamily,omitempty"`
+
+	// Font size of the value in px
+	FontSize int `json:"fontSize,omitempty"`
+
+	// Line height of the text fragment.
+	LineHeight int `json:"lineHeight,omitempty"`
+
+	// Background color of label, which is transparent by default.
+	BackgroundColor string `json:"backgroundColor,omitempty"`
+
+	// Border color of label.
+	BorderColor string `json:"borderColor,omitempty"`
+
+	// Border width of label.
+	BorderWidth int `json:"borderWidth,omitempty"`
+
+	// Border radius of label.
+	BorderRadius int `json:"borderRadius,omitempty"`
+
+	// Border type of label.
+	// Options: 'solid', 'dashed', 'dotted'
+	BorderType string `json:"borderType,omitempty"`
+
+	// Border dash offset of label.
+	BorderDashOffset int `json:"borderDashOffset,omitempty"`
+
+	// Shadow blur of text block.
+	ShadowBlur int `json:"shadowBlur,omitempty"`
+
+	// Shadow color of text block.
+	ShadowColor string `json:"shadowColor,omitempty"`
+
+	// Shadow X offset of text block.
+	ShadowOffsetX int `json:"shadowOffsetX,omitempty"`
+
+	// Shadow Y offset of text block.
+	ShadowOffsetY int `json:"shadowOffsetY,omitempty"`
+
+	// Padding title space around content. See legend.textStyle.padding
+	// The unit is px. Default values for each position are 5.
+	// And they can be set to different values with left, right, top, and bottom.
+	Padding interface{} `json:"padding,omitempty"`
+
+	// Width of text block.
+	Width int `json:"width,omitempty"`
+
+	// Height of text block.
+	Height int `json:"height,omitempty"`
+
+	// Text border color.
+	TextBorderColor string `json:"textBorderColor,omitempty"`
+
+	// Text border width.
+	TextBorderWidth int `json:"textBorderWidth,omitempty"`
+
+	// Text border type
+	// Options: 'solid', 'dashed', 'dotted'
+	TextBorderType string `json:"textBorderType,omitempty"`
+
+	// Text border dash offset.
+	TextBorderDashOffset int `json:"textBorderDashOffset,omitempty"`
+
+	// Text shadow color.
+	TextShadowColor string `json:"textShadowColor,omitempty"`
+
+	// Text shadow blur.
+	TextShadowBlur int `json:"textShadowBlur,omitempty"`
+
+	// Text shadow X offset.
+	TextShadowOffsetX int `json:"textShadowOffsetX,omitempty"`
+
+	// Text shadow Y offset.
+	TextShadowOffsetY int `json:"textShadowOffsetY,omitempty"`
+
+	// Determine how to display the text when it's overflow. Available when width is set.
+	//
+	// 'truncate' Truncate the text and trailing with ellipsis.
+	// 'break' Break by word
+	// 'breakAll' Break by character.
+	Overflow string `json:"overflow,omitempty"`
+
+	// Ellipsis
+	Ellipsis types.Bool `json:"ellipsis,omitempty"`
+
 	// The content formatter of value
 	//
 	// 1. String template
@@ -546,9 +665,6 @@ type Detail struct {
 	// The format of callback function:
 	// (value: number) => string
 	Formatter types.FuncStr `json:"formatter,omitempty"`
-
-	// Font size of the value in px
-	FontSize int `json:"fontSize,omitempty"`
 
 	// Value position relative to the center of chart
 	// OffceCenter is provided as [x, y] where x and y are either a number (px, provided

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -558,6 +558,45 @@ type Detail struct {
 	OffsetCenter []string `json:"offsetCenter,omitempty"`
 }
 
+// Pointer is the options set for Pointer (e.g. on a gauge).
+type Pointer struct {
+	// Whether to show the pointer.
+	Show types.Bool `json:"show,omitempty"` // Whether to show the pointer.
+
+	// Whether to show the pointer above detail and title.
+	ShowAbove types.Bool `json:"ShowAbove,omitempty"`
+
+	// Icon of the legend items.
+	// Icon types provided by ECharts includes
+	// 'circle', 'rect', 'roundRect', 'triangle', 'diamond', 'pin', 'arrow', 'none'
+	// It can be set to an image with 'image://url' , in which URL is the link to an image, or dataURI of an image.
+	// An image URL example:
+	//   'image://http://example.website/a/b.png'
+	// A dataURI example:
+	//
+	// 'image://data:image/gif;base64,KOY......'
+	// Icons can be set to arbitrary vector path via 'path://' in ECharts.
+	// As compared with a raster image, vector paths prevent jagging and blurring when scaled, and have better control over changing colors.
+	// For example:
+	//
+	// 'path://M30.9,53.2C16.8,...'
+	Icon string `json:"icon,omitempty"`
+
+	// Gauge
+	// Value position relative to the center of chart
+	// OffsetCenter is provided as [x, y] where x and y are either a number (px, provided
+	// as string) or a percentage.
+	// Positive values move the chart value to [right, bottom], negative values vice
+	// versa.
+	OffsetCenter []string `json:"offsetCenter,omitempty"`
+
+	// The length of pointer which could be absolute value and also the percentage relative to radius.
+	Length float64 `json:"length,omitempty"`
+
+	// The style of pointer.
+	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`
+}
+
 // CustomData
 // https://echarts.apache.org/en/option.html#series-custom.data
 type CustomData struct {

--- a/opts/charts.go
+++ b/opts/charts.go
@@ -560,10 +560,10 @@ type Detail struct {
 
 // Pointer is the options set for Pointer (e.g. on a gauge).
 type Pointer struct {
-	// Whether to show the pointer.
-	Show types.Bool `json:"show,omitempty"` // Whether to show the pointer.
+	// Whether to show the pointer, default true.
+	Show types.Bool `json:"show,omitempty"`
 
-	// Whether to show the pointer above detail and title.
+	// Whether to show the pointer above detail and title, default true.
 	ShowAbove types.Bool `json:"ShowAbove,omitempty"`
 
 	// Icon of the legend items.
@@ -590,8 +590,8 @@ type Pointer struct {
 	// versa.
 	OffsetCenter []string `json:"offsetCenter,omitempty"`
 
-	// The length of pointer which could be absolute value and also the percentage relative to radius.
-	Length float64 `json:"length,omitempty"`
+	// The length of pointer which could be absolute value and also the percentage relative to radius, e.g. '60' or '60%'.
+	Length string `json:"length,omitempty"`
 
 	// The style of pointer.
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`

--- a/opts/text_style.go
+++ b/opts/text_style.go
@@ -1,5 +1,7 @@
 package opts
 
+import "github.com/go-echarts/go-echarts/v2/types"
+
 // TextStyle is the option set for a text style component.
 type TextStyle struct {
 	// Font color
@@ -24,6 +26,89 @@ type TextStyle struct {
 
 	// Font size
 	FontSize int `json:"fontSize,omitempty"`
+
+	// Width of text block.
+	Width int `json:"width,omitempty"`
+
+	// Height of text block.
+	Height int `json:"height,omitempty"`
+
+	// Horizontal alignment of text, automatic by default.
+	// Options: 'left', 'center', 'right'
+	Align string `json:"align,omitempty"`
+
+	// Vertical alignment of text, automatic by default.
+	// Options: 'top', 'middle', 'bottom'
+	VerticalAlign string `json:"verticalAlign,omitempty"`
+
+	// Line height of the text fragment.
+	LineHeight int `json:"lineHeight,omitempty"`
+
+	// Text border color.
+	TextBorderColor string `json:"textBorderColor,omitempty"`
+
+	// Text border width.
+	TextBorderWidth int `json:"textBorderWidth,omitempty"`
+
+	// Text border type
+	// Options: 'solid', 'dashed', 'dotted'
+	TextBorderType string `json:"textBorderType,omitempty"`
+
+	// Text border dash offset.
+	TextBorderDashOffset int `json:"textBorderDashOffset,omitempty"`
+
+	// Text shadow color.
+	TextShadowColor string `json:"textShadowColor,omitempty"`
+
+	// Text shadow blur.
+	TextShadowBlur int `json:"textShadowBlur,omitempty"`
+
+	// Text shadow X offset.
+	TextShadowOffsetX int `json:"textShadowOffsetX,omitempty"`
+
+	// Text shadow Y offset.
+	TextShadowOffsetY int `json:"textShadowOffsetY,omitempty"`
+
+	// Determine how to display the text when it's overflow. Available when width is set.
+	//
+	// 'truncate' Truncate the text and trailing with ellipsis.
+	// 'break' Break by word
+	// 'breakAll' Break by character.
+	Overflow string `json:"overflow,omitempty"`
+
+	// Ellipsis
+	Ellipsis types.Bool `json:"ellipsis,omitempty"`
+
+	// Background color of label, which is transparent by default.
+	BackgroundColor string `json:"backgroundColor,omitempty"`
+
+	// Border color of label.
+	BorderColor string `json:"borderColor,omitempty"`
+
+	// Border width of label.
+	BorderWidth int `json:"borderWidth,omitempty"`
+
+	// Border radius of label.
+	BorderRadius int `json:"borderRadius,omitempty"`
+
+	// Border type of label.
+	// Options: 'solid', 'dashed', 'dotted'
+	BorderType string `json:"borderType,omitempty"`
+
+	// Border dash offset of label.
+	BorderDashOffset int `json:"borderDashOffset,omitempty"`
+
+	// Shadow blur of text block.
+	ShadowBlur int `json:"shadowBlur,omitempty"`
+
+	// Shadow color of text block.
+	ShadowColor string `json:"shadowColor,omitempty"`
+
+	// Shadow X offset of text block.
+	ShadowOffsetX int `json:"shadowOffsetX,omitempty"`
+
+	// Shadow Y offset of text block.
+	ShadowOffsetY int `json:"shadowOffsetY,omitempty"`
 
 	// Padding title space around content. See legend.textStyle.padding
 	// The unit is px. Default values for each position are 5.


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description
> Please share your ideas and awesome changes to let us know more :)

- 新增guage配置项：Progress、Detail的字段
-  想法：新增了TextStyle配置项中的字段，但是[title.textStyle](https://echarts.apache.org/en/option.html#title)中是没有Ellipsis之后的相关字段，之所以加上，我认为都属于对文本文字样式的设置，并且有跟多地方可以复用，例如gauge中的[detail](https://echarts.apache.org/option.html#series-gauge.data.detail)，其本质也属于文本文字的范畴，所有有没有可能像这样定义结构体，其他相同的地方亦是如此。
![A1A57496-189C-455c-87B2-F286AAEA2BED](https://github.com/user-attachments/assets/0fe178d3-4d54-497d-bc39-d61537cbb599)


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

