### PR TITLE
Add AreaColor to ItemStyle

### DIFF
--- a/opts/series.go
+++ b/opts/series.go
@@ -159,6 +159,9 @@ type ItemStyle struct {
 	// Kline Down candle color
 	Color0 string `json:"color0,omitempty"`
 
+	// Geo area filling color
+	AreaColor string `json:"areaColor,omitempty"`
+
 	// BorderColor is the hart border color
 	// Kline  Up candle border color
 	BorderColor string `json:"borderColor,omitempty"`


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

This PR adds the [areaColor](https://echarts.apache.org/en/option.html#geo.itemStyle.areaColor) to the `ItemStyle` options.
It can be used to set the fill color of map tiles.

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

