### PR TITLE
update(base): add progressive, progressiveTreshold options for base c…

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -67,6 +67,12 @@ type BaseConfiguration struct {
 	AnimationEasingUpdate   string        `json:"animationEasingUpdate,omitempty"`
 	AnimationDelayUpdate    types.FuncStr `json:"animationDelayUpdate,omitempty"`
 
+	//Progressive specifies the amount of graphic elements that can be rendered within a frame (about 16ms) if "progressive rendering" enabled.
+	//By default, progressive is auto-enabled when data amount is bigger than progressiveThreshold
+	Progressive types.Int `json:"progressive,omitempty"`
+	//ProgressiveThreshold number If current data amount is over the threshold, "progressive rendering" is enabled, default 3000
+	ProgressiveTreshold types.Int `json:"progressiveTreshold,omitempty"`
+
 	// Array of datasets, managed by AddDataset()
 	DatasetList []opts.Dataset `json:"dataset,omitempty"`
 
@@ -119,6 +125,15 @@ func (bc *BaseConfiguration) json() map[string]interface{} {
 
 	if bc.Animation != nil {
 		obj["animation"] = bc.Animation
+	}
+
+	if bc.Progressive != nil {
+		obj["progressive"] = bc.Animation
+
+	}
+
+	if bc.ProgressiveTreshold != nil {
+		obj["progressiveTreshold"] = bc.ProgressiveTreshold
 	}
 
 	// if only one item, use it directly instead of an Array
@@ -286,6 +301,20 @@ func WithTitleOpts(opt opts.Title) GlobalOpts {
 func WithAnimation(enable bool) GlobalOpts {
 	return func(bc *BaseConfiguration) {
 		bc.Animation = opts.Bool(enable)
+	}
+}
+
+// WithProgressive allows to set amount of graphic elements rendered in a frame
+func WithProgressive(opt int) GlobalOpts {
+	return func(bc *BaseConfiguration) {
+		bc.Progressive = opts.Int(opt)
+	}
+}
+
+// Allows to set treshold for progressive rendering
+func WithProgressiveThreshold(opt int) GlobalOpts {
+	return func(bc *BaseConfiguration) {
+		bc.ProgressiveTreshold = opts.Int(opt)
 	}
 }
 


### PR DESCRIPTION

<!-- Thanks for you contribution !!! -->

# Description
I have been using go-echarts with go-echarts/snapshot-chromedp for generating charts jpg. The issue i runned up with was related particulary with heatmap and the amount of elements is was rendering. While using it with snapshot-chromedp it was going into progressive render mode which was causing the screenshot of heatmap to contain only half of chart (in loading state). I have added extension to base chart settings to allow for customization of those settings.  

> Please share your ideas and awesome changes to let us know more :)


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
--> none

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

