### PR TITLE
update(opt): add AxisLine to XAxis

### DIFF
--- a/opts/x_axis.go
+++ b/opts/x_axis.go
@@ -100,6 +100,9 @@ type XAxis struct {
 	// Split line of X axis in grid area.
 	SplitLine *SplitLine `json:"splitLine,omitempty"`
 
+	// Settings related to axis line.
+	AxisLine *AxisLine `json:"axisLine,omitempty"`
+
 	// Settings related to axis label.
 	AxisLabel *AxisLabel `json:"axisLabel,omitempty"`
 


### PR DESCRIPTION
# Description
Currently there is no way to style the `XAxis` in the contrast to `YAxis`

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->
As stated in the Apache Echarts official documentation ([here](https://echarts.apache.org/en/option.html#xAxis.axisLine)), there is an `axisLine` property for both `xAxis` and `yAxis`, however currently only `yAxis` has that property exclusively. By adding it also to `XAxis` the styling, (not)-showing the axis can be configured, as is depicted on the following screenshots:
![image](https://github.com/user-attachments/assets/2a13b856-88c9-4fb0-8b8a-e4500b6ae6bd)
<img width="409" alt="Screenshot 2025-01-08 at 15 01 20" src="https://github.com/user-attachments/assets/1784fe3c-f727-4522-861d-958617af2b25" />