### PR TITLE
provide new overlapWithYAxis func to extend overlap for multi YAxis

### DIFF
--- a/charts/rectangle.go
+++ b/charts/rectangle.go
@@ -6,6 +6,7 @@ import (
 
 type Overlaper interface {
 	overlap() MultiSeries
+	getRectChart() *RectChart
 }
 
 // XYAxis represent the X and Y axis in the rectangular coordinates.
@@ -73,6 +74,10 @@ func (rc *RectChart) overlap() MultiSeries {
 	return rc.MultiSeries
 }
 
+func (rc *RectChart) getRectChart() *RectChart {
+	return rc
+}
+
 // SetGlobalOptions sets options for the RectChart instance.
 func (rc *RectChart) SetGlobalOptions(options ...GlobalOpts) *RectChart {
 	rc.RectConfiguration.setRectGlobalOptions(options...)
@@ -84,6 +89,18 @@ func (rc *RectChart) SetGlobalOptions(options ...GlobalOpts) *RectChart {
 // Supported charts: Bar/BoxPlot/Line/Scatter/EffectScatter/Kline/HeatMap/Custom
 func (rc *RectChart) Overlap(a ...Overlaper) {
 	for i := 0; i < len(a); i++ {
+		rc.MultiSeries = append(rc.MultiSeries, a[i].overlap()...)
+	}
+}
+
+// OverlapWithYAxis extend Overlap with the Y axis
+func (rc *RectChart) OverlapWithYAxis(a ...Overlaper) {
+	for i := 0; i < len(a); i++ {
+		rect := a[i].getRectChart()
+		rect.MultiSeries.SetSeriesOptions(WithSeriesOpts(func(s *SingleSeries) {
+			s.YAxisIndex = len(rc.YAxisList)
+		}))
+		rc.ExtendYAxis(rect.YAxisList...)
 		rc.MultiSeries = append(rc.MultiSeries, a[i].overlap()...)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

the original func `Overlap` only move the series data, I provide a new func `OverlapWithYAxis` which could set the YAxis info into the chart, Simultaneously it ensures the data of `Overlaper` followed the YAxisIndex 

<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

