### PR TITLE
Add tooltip.Position function

### DIFF
--- a/opts/tooltip.go
+++ b/opts/tooltip.go
@@ -89,6 +89,12 @@ type Tooltip struct {
 
 	ValueFormatter string `json:"valueFormatter,omitempty"`
 
+	// The content formatter of tooltip's floating layer which supports string template and callback function.
+	// See https://echarts.apache.org/en/option.html#grid.tooltip.position
+	// May be a string ("inside", "top", "bottom", "left", "right") or a function of form:
+	//   (point: Array, params: Object|Array.<Object>, dom: HTMLDomElement, rect: Object, size: Object) => Array
+	Position types.FuncStr `json:"position,omitempty"`
+
 	// The border color of tooltip's floating layer.
 	BorderColor string `json:"borderColor,omitempty"`
 


### PR DESCRIPTION
https://echarts.apache.org/en/option.html#grid.tooltip.position

<!-- Thanks for you contribution !!! -->

# Description

I was seeking to do tooltip positioning like [this ECharts candlestick example](https://echarts.apache.org/examples/en/editor.html?c=candlestick-brush), but discovered that it wasn't exposed by `go-echarts`.

I added the binding to it.   I tested it with positioning code there :

```javascript
// tooltipPositioner.js
function (pos, params, el, elRect, size) {
          const obj = {
            top: 10
          };
          obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 30;
          return obj;
        }
```

```golang
//go:embed js/tooltipPositioner.js
var tooltipPositioner string

func makeCharts() {
......
	charts.WithTooltipOpts(opts.Tooltip{
		Show:        opts.Bool(true),
		Trigger:     "axis",
		AxisPointer: &opts.AxisPointer{Type: "line"},
		Position: types.FuncStr(opts.FuncStripCommentsOpts(tooltipPositioner)),
	})
}
```
---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [ X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->
I could make an example with the above code.
 
