### PR TITLE
added BarWidth property to opts.BarCharts

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -287,6 +287,7 @@ func WithBarChartOpts(opt opts.BarChart) SeriesOpts {
 		s.Stack = opt.Stack
 		s.BarGap = opt.BarGap
 		s.BarCategoryGap = opt.BarCategoryGap
+		s.BarWidth = opt.BarWidth
 	}
 }
 

--- a/opts/series_bar.go
+++ b/opts/series_bar.go
@@ -52,7 +52,10 @@ type BarChart struct {
 	// then it will be adopted by all 'bar' series in the coordinate system.
 	BarCategoryGap string
 
-	// Specify bar width. Absolute value (like 10) or percentage (like '20%', according to band width) can be used. Auto adapt by default.
+	// The width of the bar. Adaptive when not specified.
+        // Can be an absolute value like 40 or a percent value like '60%'. The percent is based on the calculated category width.
+        // In a single coordinate system, this attribute is shared by multiple 'bar' series. 
+	// This attribute should be set on the last 'bar' series in the coordinate system, then it will be adopted by all 'bar' series in the coordinate system.
 	BarWidth string
 }
 

--- a/opts/series_bar.go
+++ b/opts/series_bar.go
@@ -53,8 +53,8 @@ type BarChart struct {
 	BarCategoryGap string
 
 	// The width of the bar. Adaptive when not specified.
-        // Can be an absolute value like 40 or a percent value like '60%'. The percent is based on the calculated category width.
-        // In a single coordinate system, this attribute is shared by multiple 'bar' series. 
+	// Can be an absolute value like 40 or a percent value like '60%'. The percent is based on the calculated category width.
+	// In a single coordinate system, this attribute is shared by multiple 'bar' series.
 	// This attribute should be set on the last 'bar' series in the coordinate system, then it will be adopted by all 'bar' series in the coordinate system.
 	BarWidth string
 }

--- a/opts/series_bar.go
+++ b/opts/series_bar.go
@@ -51,6 +51,9 @@ type BarChart struct {
 	// This attribute should be set on the last 'bar' series in the coordinate system,
 	// then it will be adopted by all 'bar' series in the coordinate system.
 	BarCategoryGap string
+
+	// Specify bar width. Absolute value (like 10) or percentage (like '20%', according to band width) can be used. Auto adapt by default.
+	BarWidth string
 }
 
 // BarData


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

> Please share your ideas and awesome changes to let us know more :)

Added the missing BarWidth option to the BarChart type. 

<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

