### PR TITLE
Add series id

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -9,7 +9,7 @@ import (
 type SingleSeries struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
-	Id   string `json:"id,omitempty"`
+	SeriesId string `json:"id,omitempty"`
 
 	// Rectangular charts
 	// Line | Bar
@@ -187,9 +187,9 @@ func WithSeriesOpts(opf SingleSeriesOptFunc) SeriesOpts {
 	}
 }
 
-func WithId(id string) SeriesOpts {
+func WithSeriesId(id string) SeriesOpts {
 	return func(s *SingleSeries) {
-		s.Id = id
+		s.SeriesId = id
 	}
 }
 

--- a/charts/series.go
+++ b/charts/series.go
@@ -9,7 +9,7 @@ import (
 type SingleSeries struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
-	Id string `json:"id,omitempty"`
+	Id   string `json:"id,omitempty"`
 
 	// Rectangular charts
 	// Line | Bar

--- a/charts/series.go
+++ b/charts/series.go
@@ -9,7 +9,7 @@ import (
 type SingleSeries struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
-	SeriesId string `json:"id,omitempty"`
+	Id string `json:"id,omitempty"`
 
 	// Rectangular charts
 	// Line | Bar
@@ -189,7 +189,7 @@ func WithSeriesOpts(opf SingleSeriesOptFunc) SeriesOpts {
 
 func WithSeriesId(id string) SeriesOpts {
 	return func(s *SingleSeries) {
-		s.SeriesId = id
+		s.Id = id
 	}
 }
 

--- a/charts/series.go
+++ b/charts/series.go
@@ -9,6 +9,7 @@ import (
 type SingleSeries struct {
 	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
+	Id   string `json:"id,omitempty"`
 
 	// Rectangular charts
 	// Line | Bar
@@ -183,6 +184,12 @@ type SingleSeriesOptFunc func(s *SingleSeries)
 func WithSeriesOpts(opf SingleSeriesOptFunc) SeriesOpts {
 	return func(s *SingleSeries) {
 		opf(s)
+	}
+}
+
+func WithId(id string) SeriesOpts {
+	return func(s *SingleSeries) {
+		s.Id = id
 	}
 }
 

--- a/docs/en-us/options/series.md
+++ b/docs/en-us/options/series.md
@@ -12,6 +12,7 @@ The Series Options list:
 type SingleSeries struct {
     Name string `json:"name,omitempty"`
     Type string `json:"type,omitempty"`
+    Id   string `json:"id,omitempty"`
 
     // Rectangular charts
     // Line | Bar


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

Allows setting the series id using `charts.WithId`:

```go
line.AddSeries("series-name", data, charts.WithSeriesId("a"))
```

Fixes #453


---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

