### PR TITLE
Support setting area opacity to 0

### DIFF
--- a/opts/series.go
+++ b/opts/series.go
@@ -179,7 +179,7 @@ type ItemStyle struct {
 	GapWidth float32 `json:"gapWidth,omitempty"`
 
 	// Opacity of the component. Supports value from 0 to 1, and the component will not be drawn when set to 0.
-	Opacity float32 `json:"opacity,omitempty"`
+	Opacity types.Float `json:"opacity,omitempty"`
 
 	// ShadowBlur Size of shadow blur.
 	// This attribute should be used along with shadowColor,shadowOffsetX, shadowOffsetY to set shadow to component.
@@ -493,7 +493,7 @@ type LineStyle struct {
 	Type string `json:"type,omitempty"`
 
 	// Opacity of the component. Supports value from 0 to 1, and the component will not be drawn when set to 0.
-	Opacity float32 `json:"opacity,omitempty"`
+	Opacity types.Float `json:"opacity,omitempty"`
 
 	// Curveness of edge. The values from 0 to 1 could be set.
 	// it would be larger as the the value becomes larger. default 0
@@ -516,7 +516,7 @@ type AreaStyle struct {
 	Origin string `json:"origin,omitempty"`
 
 	// Opacity of the component. Supports value from 0 to 1, and the component will not be drawn when set to 0.
-	Opacity float32 `json:"opacity"`
+	Opacity types.Float `json:"opacity,omitempty"`
 }
 
 // GraphForce Configuration items about force-directed layout. Force-directed layout simulates

--- a/opts/series.go
+++ b/opts/series.go
@@ -516,7 +516,7 @@ type AreaStyle struct {
 	Origin string `json:"origin,omitempty"`
 
 	// Opacity of the component. Supports value from 0 to 1, and the component will not be drawn when set to 0.
-	Opacity float32 `json:"opacity,omitempty"`
+	Opacity float32 `json:"opacity"`
 }
 
 // GraphForce Configuration items about force-directed layout. Force-directed layout simulates


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

> Please share your ideas and awesome changes to let us know more :)

This fixes a problem where you could not remove an area fill from an existing chart that was updated with replaceMerge, because the opacity was not serialized when set to 0.

<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

