### PR TITLE
update(opt): add calendar.dayLabel. firstDay

### DIFF
--- a/opts/calendar.go
+++ b/opts/calendar.go
@@ -61,6 +61,8 @@ type CalendarLabel struct {
 	// Whether to show the label.
 	Show types.Bool `json:"show,omitempty"`
 
+	FirstDay int `json:"firstDay,omitempty"`
+
 	// The margin between the month label and the axis line.
 	Margin float64 `json:"margin,omitempty"`
 


### PR DESCRIPTION
Add a missing firstDay option for calendar
https://echarts.apache.org/en/option.html#calendar.dayLabel.firstDay

* Add field FirstDay in strut CalendarLabel

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
=> Not for this add.
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

