### PR TITLE
Feature/chart id chart snippet

### DIFF
--- a/charts/base.go
+++ b/charts/base.go
@@ -260,13 +260,8 @@ func (bc *BaseConfiguration) initSeriesColors() {
 	}
 }
 
-func (bc *BaseConfiguration) insertSeriesColors(colors []string) {
-	reversed := reverseSlice(colors)
-	for i := 0; i < len(reversed); i++ {
-		bc.Colors = append(bc.Colors, "")
-		copy(bc.Colors[1:], bc.Colors[0:])
-		bc.Colors[0] = reversed[i]
-	}
+func (bc *BaseConfiguration) setSeriesColors(colors []string) {
+	bc.Colors = colors
 }
 
 func (bc *BaseConfiguration) setBaseGlobalOptions(opts ...GlobalOpts) {
@@ -430,16 +425,8 @@ func WithParallelAxisList(opt []opts.ParallelAxis) GlobalOpts {
 // WithColorsOpts sets the color.
 func WithColorsOpts(opt opts.Colors) GlobalOpts {
 	return func(bc *BaseConfiguration) {
-		bc.insertSeriesColors(opt)
+		bc.setSeriesColors(opt)
 	}
-}
-
-// reverseSlice reverses the string slice.
-func reverseSlice(s []string) []string {
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
-	}
-	return s
 }
 
 // WithGridOpts sets the List of the grid.

--- a/render/chart.go
+++ b/render/chart.go
@@ -61,6 +61,13 @@ func (r *chartRender) RenderSnippet() ChartSnippet {
 	}
 	snippet.Element = string(pat.ReplaceAll(elementBuf.Bytes(), []byte("")))
 
+	chartIdTpl := MustTemplate(ModChart, []string{templates.BaseTpl, templates.ChartIDTpl})
+	var chartIdBuf bytes.Buffer
+	if err := chartIdTpl.ExecuteTemplate(&chartIdBuf, ModChart, r.c); err != nil {
+		panic(err)
+	}
+	snippet.ChartID = chartIdBuf.String()
+
 	scriptTpl := MustTemplate(ModChart, []string{templates.BaseTpl, templates.BaseScriptTpl})
 	var scriptBuf bytes.Buffer
 	if err := scriptTpl.ExecuteTemplate(&scriptBuf, ModChart, r.c); err != nil {

--- a/render/engine.go
+++ b/render/engine.go
@@ -23,6 +23,7 @@ var pat = regexp.MustCompile(`(__f__")|("__f__)|(__f__)`)
 
 type ChartSnippet struct {
 	Element string
+	ChartID string
 	Script  string
 	Option  string
 }

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -33,3 +33,7 @@
     {{- template "base_element" . }}
     {{- template "base_script" . }}
 {{- end }}
+
+{{- define "chart_id" -}}
+{{$.ChartID}}
+{{- end -}}

--- a/templates/chart_id.tpl
+++ b/templates/chart_id.tpl
@@ -1,0 +1,1 @@
+{{- template "chart_id" . }}

--- a/templates/template.go
+++ b/templates/template.go
@@ -10,6 +10,9 @@ var BaseTpl string
 //go:embed chart.tpl
 var ChartTpl string
 
+//go:embed chart_id.tpl
+var ChartIDTpl string
+
 //go:embed header.tpl
 var HeaderTpl string
 


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

Add `ChartID` to `ChartSnippet` – so that it can easily be accessed for further operations directly from a `RenderSnippet()` call.

Is this the right place to have it? Found myself having to create intermediate structs like: 

```go
type MyChart struct {
    ChartID string
    Snippet charts.ChartSnippet
}
```
 In order to conveniently do further work with the ID. 


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

-->
Fixes #570. Related to #569 – the operations in that (resize observer) is what I was using the ID for. 

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

