### PR TITLE
Resize observer

### DIFF
--- a/opts/global.go
+++ b/opts/global.go
@@ -42,7 +42,7 @@ type Initialization struct {
 	Renderer string `default:"canvas"`
 
 	// Wether to create a ResizeObserver to observe the chart and make calls to echartsInstance.resize()
-	Resize bool `default:"false"`
+	Resize types.Bool `default:"false"`
 
 	// Page configurations duplicate, a shortcut for single chart build with page settings
 	PageTitle string `default:"Awesome go-echarts"`

--- a/render/engine.go
+++ b/render/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -44,6 +45,17 @@ func MustTemplate(name string, contents []string) *template.Template {
 		},
 		"safeJS": func(s interface{}) template.JS {
 			return template.JS(fmt.Sprint(s))
+		},
+		"deref": func(v interface{}) interface{} {
+			rv := reflect.ValueOf(v)
+			if rv.Kind() == reflect.Ptr {
+				if rv.IsNil() {
+					return nil // nil pointer stays nil
+				}
+				return rv.Elem().Interface()
+			}
+			// not a pointer, return as-is
+			return v
 		},
 		"injectInstance": func(funcStr types.FuncStr, echartsInstancePlaceholder string, chartID string) string {
 			instance := EchartsInstancePrefix + chartID

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -19,7 +19,7 @@
     {{ end }}
   {{- end }}
 
-  {{if $.Initialization.Resize -}}
+  {{if eq (deref $.Initialization.Resize) true -}}
     new ResizeObserver((charts) => charts.forEach(c => {
       echarts.getInstanceByDom(c.target).resize();
     })).observe(document.getElementById('{{$.ChartID  | safeJS}}'));

--- a/util/default_val_setter.go
+++ b/util/default_val_setter.go
@@ -35,7 +35,7 @@ func setField(field reflect.Value, defaultVal string) {
 			field.Set(reflect.ValueOf(defaultVal).Convert(field.Type()))
 		}
 	case reflect.Bool:
-		if val, err := strconv.ParseBool(defaultVal); err == nil && !field.Bool() {
+		if val, err := strconv.ParseBool(defaultVal); err == nil {
 			field.Set(reflect.ValueOf(val).Convert(field.Type()))
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

Add the option to add a `ResizeObserver` to the `echartsInstance`, that will make calls to `.resize()`. In order to save time and lines of code. Useful when specifying something like `"50%"` or `"10vh"` as height or width of the chart – if the chart isn't resized it would look strange if the browser window changes its size.

<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->
Fixes #569 
---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

