### PR TITLE
`Label.Formatter` as `types.FuncStr`

### DIFF
--- a/opts/series.go
+++ b/opts/series.go
@@ -101,7 +101,7 @@ type Label struct {
 	// {c}: the value of a data item.
 	// {@xxx}: the value of a dimension named"xxx", for example,{@product}refers the value of"product"` dimension.
 	// {@[n]}: the value of a dimension at the index ofn, for example,{@[3]}` refers the value at dimensions[3].
-	Formatter string `json:"formatter,omitempty"`
+	Formatter types.FuncStr `json:"formatter,omitempty"`
 }
 
 // LabelLine Configuration of label guide line.


### PR DESCRIPTION
<!-- Thanks for you contribution !!! -->

# Description

See this https://echarts.apache.org/en/option.html#series-bar.label.formatter and example https://echarts.apache.org/examples/en/editor.html?c=bar-stack-normalization

Need a way to format the label using a function. Backwards compatible to change from `string` to `types.FuncStr`?


<!-- Please include a summary of the change or which issue is fixed. Please also include relevant motivation and context.
List any dependencies/documents that are required for this change is a plus.

Fixes # (issue number if exists)
-->

---

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [X] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others

<!-- details -->



---

<!--
If there contains new features of charts, are you willing to submit a PR
on [go-echarts/Examples](https://github.com/go-echarts/examples)?
> This is absolutely not required, but we are happy to see that you could share or update the related
> charts' examples to benefit more users.

Consider to submit a PR on [Examples](https://github.com/go-echarts/examples)!

 -->

