### PR TITLE
update(opts): add roam to geo chart with progressive render disabled

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -136,7 +136,7 @@ type SingleSeries struct {
 	// series with many data points.
 	// Set progressive to 0 to disable progressive rendering.
 	Progressive          types.Int `json:"progressive"`
-	ProgressiveThreshold int       `json:"progressiveThreshold"`
+	ProgressiveThreshold types.Int `json:"progressiveThreshold"`
 
 	// Gauge
 	Progress   *opts.Progress  `json:"progress,omitempty"`

--- a/charts/series.go
+++ b/charts/series.go
@@ -135,8 +135,8 @@ type SingleSeries struct {
 	// different canvas layers to avoid blocking the UI thread of the browser for
 	// series with many data points.
 	// Set progressive to 0 to disable progressive rendering.
-	Progressive          types.Int `json:"progressive"`
-	ProgressiveThreshold types.Int `json:"progressiveThreshold"`
+	Progressive          types.Int `json:"progressive,omitempty"`
+	ProgressiveThreshold types.Int `json:"progressiveThreshold,omitempty"`
 
 	// Gauge
 	Progress   *opts.Progress  `json:"progress,omitempty"`

--- a/charts/series.go
+++ b/charts/series.go
@@ -128,6 +128,16 @@ type SingleSeries struct {
 	Data         interface{} `json:"data,omitempty"`
 	DatasetIndex int         `json:"datasetIndex,omitempty"`
 
+	// Bar | Lines | Scatter | Heatmap | Parallel | Candlestick
+	// Progressive specifies the amount of graphic elements that can be rendered
+	// within a frame (about 16ms) if "progressive rendering" is enabled.
+	// "Progressive rendering" processes and renders data chunk by chunk on
+	// different canvas layers to avoid blocking the UI thread of the browser for
+	// series with many data points.
+	// Set progressive to 0 to disable progressive rendering.
+	Progressive          types.Int `json:"progressive"`
+	ProgressiveThreshold int       `json:"progressiveThreshold"`
+
 	// Gauge
 	Progress   *opts.Progress  `json:"progress,omitempty"`
 	AxisTick   *opts.AxisTick  `json:"axisTick,omitempty"`

--- a/opts/geo.go
+++ b/opts/geo.go
@@ -8,6 +8,27 @@ type GeoComponent struct {
 	// Map charts.
 	Map string `json:"map,omitempty"`
 
+	// Specifies which point on the map should be placed at center of viewport.
+	// When roaming, values in center and zoom will be modified correspondingly.
+	// Center is in longitude and latitude by default. Use the projected coordinates.
+	// Example: [115.97, 29.71].
+	// A percentage string can also be used, like '30%', based on the bounding rect.
+	// You can use '0%' to place the top or left of bounding rect to the center,
+	// or use '50%' to place the entire source map at the the center of the viewport.
+	// Example: [115, '30%'].
+	Center interface{} `json:"center,omitempty"`
+
+	// Zoom rate of current viewport. The value less than 1 indicates zooming out,
+	// while the value greater than 1 indicates zooming in.
+	// When roaming, values in center and zoom will be modified correspondingly.
+	Zoom types.Float `json:"zoom,omitempty"`
+
+	// Whether to enable mouse or touch roam (move and zoom):
+	// * false: roam is disabled.
+	// * true: both zoom and move (translation) are available.
+	// When roaming, values in center and zoom will be modified correspondingly.
+	Roam types.Bool `json:"roam,omitempty"`
+
 	// Graphic style of Map Area Border, emphasis is the style when it is highlighted,
 	// like being hovered by mouse, or highlighted via legend connect.
 	ItemStyle *ItemStyle `json:"itemStyle,omitempty"`


### PR DESCRIPTION
The Geo roam option makes for more fun interactions with maps, and are useful to explore maps with details or large series on top. Roam updates center and zoom but go-echarts developer might want to set these to some initial value, to start the user off with a particular part of the map in view.

Unfortunately adding a series with many data points to a Geo chart can lead to a visual bug, when a user roams around the map but the series remains static and does not move "with" the map. This can be resolved by disabling progressive rendering, which causes large data series to be rendered on separate canvas layers (for performance reasons) and therefore prevents them from participating in transformations to the Geo chart.

This PR adds the mentioned Geo options, and Series options to disable progressive rendering or configure the threshold to a larger number. For example Apache ECharts docs shows the default threshold at which progressive rendering is enabled for a Scatter Series [here](https://echarts.apache.org/en/option.html#series-scatter.progressiveThreshold)

# Type of change

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Would cause existing functionality to not work as expected)
- [ ] Docs
- [ ] Others